### PR TITLE
feat: add rules for border and rounded

### DIFF
--- a/plugin/checkFabricClasses.js
+++ b/plugin/checkFabricClasses.js
@@ -1,5 +1,5 @@
 import { createGenerator } from '@unocss/core'
-import presetEngine from './src/index.js'
+import presetEngine from '#plugin'
 import { buildList } from '@warp-ds/fabric-parity-checker'
 
 const fabricClassListWithoutClassDots = buildList().map(e => e.replace('.', ''))

--- a/plugin/src/_rules/border.js
+++ b/plugin/src/_rules/border.js
@@ -31,8 +31,7 @@ function handlerBorder(m, ctx) {
 }
 
 function handlerBorderSize([, a = "", b], { theme }) {
-  const v =
-    theme.lineWidth?.[b || "DEFAULT"] ?? h.bracket.cssvar.global.px(b || "1");
+  const v = theme.lineWidth?.[b ?? 2] ?? h.global(b);
   if (a in directionMap && v != null)
     return directionMap[a].map((i) => [`border${i}-width`, v]);
 }
@@ -51,7 +50,7 @@ export const rounded = [
 ]
 
 function handlerRounded([, a = '', s], { theme }) {
-  const v = theme.borderRadius?.[s || 'DEFAULT'] || h.bracket.cssvar.global.fraction.rem(s || '1');
+  const v = theme.borderRadius?.[s ?? 2] || h.global(s);
   if (a in cornerMap && v != null)
       return cornerMap[a].map(i => [`border${i}-radius`, v]);
 }

--- a/plugin/src/_rules/border.js
+++ b/plugin/src/_rules/border.js
@@ -1,0 +1,45 @@
+import { handler as h, directionMap, cornerMap } from "#utils";
+
+const borderStyles = [
+  "solid",
+  "dashed",
+  "dotted",
+  "double",
+  "hidden",
+  "none",
+  "groove",
+  "ridge",
+  "inset",
+  "outset",
+];
+
+export const borders = [
+  [/^border$/, handlerBorder],
+  [/^border()-(\d+)$/, handlerBorder, { autocomplete: "(border)-<directions>" }],
+  [/^border-([xy])-(\d+)$/, handlerBorder],
+  [/^border-([rltb])$/, handlerBorder],
+  [/^border-([rltb])-(\d+)$/, handlerBorder],
+  [/^border()-(.+)$/, handlerBorderStyle, { autocomplete: "(border)-<directions>" }],
+  [/^border-([xy])-(.+)$/, handlerBorderStyle],
+  [/^border-([rltb])-(.+)$/, handlerBorderStyle],
+];
+
+function handlerBorder(m, ctx) {
+  const borderSizes = handlerBorderSize(m, ctx);
+  const borderStyle = handlerBorderStyle(["", m[1], "solid"]);
+  if (borderSizes && borderStyle) {
+    return [...borderSizes, ...borderStyle];
+  }
+}
+
+function handlerBorderSize([, a = "", b], { theme }) {
+  const v =
+    theme.lineWidth?.[b || "DEFAULT"] ?? h.bracket.cssvar.global.px(b || "1");
+  if (a in directionMap && v != null)
+    return directionMap[a].map((i) => [`border${i}-width`, v]);
+}
+
+function handlerBorderStyle([, a = "", s]) {
+  if (borderStyles.includes(s) && a in directionMap)
+    return directionMap[a].map((i) => [`border${i}-style`, s]);
+}

--- a/plugin/src/_rules/border.js
+++ b/plugin/src/_rules/border.js
@@ -50,7 +50,7 @@ export const rounded = [
 ]
 
 function handlerRounded([, a = '', s], { theme }) {
-  const v = theme.borderRadius?.[s ?? 1] || h.global(s);
+  const v = theme.borderRadius?.[s ?? 4] || h.global(s);
   if (a in cornerMap && v != null)
       return cornerMap[a].map(i => [`border${i}-radius`, v]);
 }

--- a/plugin/src/_rules/border.js
+++ b/plugin/src/_rules/border.js
@@ -19,7 +19,7 @@ export const borders = [
   [/^border-([xy])-(\d+)$/, handlerBorder],
   [/^border-([rltb])$/, handlerBorder],
   [/^border-([rltb])-(\d+)$/, handlerBorder],
-  [/^border()-(.+)$/, handlerBorderStyle, { autocomplete: "(border)-<directions>" }],
+  [/^border()-(.+)$/, handlerBorderStyle, { autocomplete: "(border)-style" }],
   [/^border-([xy])-(.+)$/, handlerBorderStyle],
   [/^border-([rltb])-(.+)$/, handlerBorderStyle],
 ];
@@ -42,4 +42,18 @@ function handlerBorderSize([, a = "", b], { theme }) {
 function handlerBorderStyle([, a = "", s]) {
   if (borderStyles.includes(s) && a in directionMap)
     return directionMap[a].map((i) => [`border${i}-style`, s]);
+}
+
+export const rounded = [
+  [/^rounded()(?:-(.+))?$/, handlerRounded, { autocomplete: ['(rounded)', '(rounded)-<num>'] }],
+  [/^rounded-([rltb]+)(?:-(.+))?$/, handlerRounded],
+  [/^rounded([rltb]{2})(?:-(.+))?$/, handlerRounded],
+  [/^rounded-([bi][se])(?:-(.+))?$/, handlerRounded],
+  [/^rounded-([bi][se]-[bi][se])(?:-(.+))?$/, handlerRounded],
+]
+
+function handlerRounded([, a = '', s], { theme }) {
+  const v = theme.borderRadius?.[s || 'DEFAULT'] || h.bracket.cssvar.global.fraction.rem(s || '1');
+  if (a in cornerMap && v != null)
+      return cornerMap[a].map(i => [`border${i}-radius`, v]);
 }

--- a/plugin/src/_rules/border.js
+++ b/plugin/src/_rules/border.js
@@ -26,10 +26,8 @@ export const borders = [
 
 function handlerBorder(m, ctx) {
   const borderSizes = handlerBorderSize(m, ctx);
-  const borderStyle = handlerBorderStyle(["", m[1], "solid"]);
-  if (borderSizes && borderStyle) {
-    return [...borderSizes, ...borderStyle];
-  }
+
+  if (borderSizes ) return [...borderSizes];
 }
 
 function handlerBorderSize([, a = "", b], { theme }) {

--- a/plugin/src/_rules/border.js
+++ b/plugin/src/_rules/border.js
@@ -31,7 +31,7 @@ function handlerBorder(m, ctx) {
 }
 
 function handlerBorderSize([, a = "", b], { theme }) {
-  const v = theme.lineWidth?.[b ?? 2] ?? h.global(b);
+  const v = theme.lineWidth?.[b ?? 1] ?? h.global(b);
   if (a in directionMap && v != null)
     return directionMap[a].map((i) => [`border${i}-width`, v]);
 }
@@ -50,7 +50,7 @@ export const rounded = [
 ]
 
 function handlerRounded([, a = '', s], { theme }) {
-  const v = theme.borderRadius?.[s ?? 2] || h.global(s);
+  const v = theme.borderRadius?.[s ?? 1] || h.global(s);
   if (a in cornerMap && v != null)
       return cornerMap[a].map(i => [`border${i}-radius`, v]);
 }

--- a/plugin/src/_rules/border.js
+++ b/plugin/src/_rules/border.js
@@ -31,7 +31,7 @@ function handlerBorder(m, ctx) {
 }
 
 function handlerBorderSize([, a = "", b], { theme }) {
-  const v = theme.lineWidth?.[b ?? 1] ?? h.global(b);
+  const v = theme.lineWidth?.[b ?? 1];
   if (a in directionMap && v != null)
     return directionMap[a].map((i) => [`border${i}-width`, v]);
 }
@@ -50,7 +50,7 @@ export const rounded = [
 ]
 
 function handlerRounded([, a = '', s], { theme }) {
-  const v = theme.borderRadius?.[s ?? 4] || h.global(s);
+  const v = theme.borderRadius?.[s ?? 4];
   if (a in cornerMap && v != null)
       return cornerMap[a].map(i => [`border${i}-radius`, v]);
 }

--- a/plugin/src/_rules/index.js
+++ b/plugin/src/_rules/index.js
@@ -1,4 +1,5 @@
 import * as align from "./align.js";
+import * as border from "./border.js";
 import * as color from "./color.js";
 import * as display from "./display.js";
 import * as flex from "./flex.js";
@@ -12,6 +13,7 @@ import * as spacing from "./spacing.js";
 
 const ruleGroups = {
   ...align,
+  ...border,
   ...color,
   ...display,
   ...flex,
@@ -29,6 +31,7 @@ export const rules = [
 ].flat(1);
 
 export * from "./align.js";
+export * from "./border.js";
 export * from "./color.js";
 export * from "./display.js";
 export * from "./flex.js";

--- a/plugin/src/theme.js
+++ b/plugin/src/theme.js
@@ -24,16 +24,37 @@ const zIndex = {
   50: "50",
 }
 
+const lineWidth = {
+  0: "0",
+  1: "1px",
+  2: "2px",
+  4: "4px",
+  8: "8px",
+}
+
+const borderRadius = {
+  0: "0",
+  2: "2px",
+  4: "4px",
+  6: "6px",
+  8: "8px",
+  16: "16px",
+  "full": "9999px",
+}
+
 export const useTheme = (opts = {}) => {
   const baseSpacing =  opts.usePixels ? spacingInPx : spacingInRem
   const width = { ...baseSpacing, screen: '100vw' }
   const height = { ...baseSpacing, screen: '100vh' }
+
   return {
     usingPixels: !!opts.pxSpacing,
     breakpoints,
+    borderRadius,
     verticalBreakpoints: breakpoints,
     spacing: baseSpacing,
     zIndex,
+    lineWidth,
     width,
     height,
     maxWidth: { none: 'none', ...width },

--- a/plugin/test/__snapshots__/border.js.snap
+++ b/plugin/test/__snapshots__/border.js.snap
@@ -1,0 +1,123 @@
+// Vitest Snapshot v1
+
+exports[`border > right, left, top bottom 1`] = `
+"/* layer: default */
+.border-b{border-bottom-width:1px;}
+.border-l{border-left-width:1px;}
+.border-r{border-right-width:1px;}
+.border-t{border-top-width:1px;}
+.border-b-0{border-bottom-width:0;}
+.border-b-2{border-bottom-width:2px;}
+.border-b-4{border-bottom-width:4px;}
+.border-b-8{border-bottom-width:8px;}
+.border-l-0{border-left-width:0;}
+.border-l-2{border-left-width:2px;}
+.border-l-4{border-left-width:4px;}
+.border-l-8{border-left-width:8px;}
+.border-r-0{border-right-width:0;}
+.border-r-2{border-right-width:2px;}
+.border-r-4{border-right-width:4px;}
+.border-r-8{border-right-width:8px;}
+.border-t-0{border-top-width:0;}
+.border-t-2{border-top-width:2px;}
+.border-t-4{border-top-width:4px;}
+.border-t-8{border-top-width:8px;}"
+`;
+
+exports[`border > supports setting border style 1`] = `
+"/* layer: default */
+.border-dashed{border-style:dashed;}
+.border-dotted{border-style:dotted;}
+.border-double{border-style:double;}
+.border-groove{border-style:groove;}
+.border-hidden{border-style:hidden;}
+.border-inset{border-style:inset;}
+.border-none{border-style:none;}
+.border-outset{border-style:outset;}
+.border-ridge{border-style:ridge;}
+.border-solid{border-style:solid;}"
+`;
+
+exports[`border > supports setting border width 1`] = `
+"/* layer: default */
+.border{border-width:1px;}
+.border-0{border-width:0;}
+.border-2{border-width:2px;}
+.border-4{border-width:4px;}
+.border-8{border-width:8px;}"
+`;
+
+exports[`border > supports x|y with value 1`] = `
+"/* layer: default */
+.border-x-0{border-left-width:0;border-right-width:0;}
+.border-x-2{border-left-width:2px;border-right-width:2px;}
+.border-x-4{border-left-width:4px;border-right-width:4px;}
+.border-x-8{border-left-width:8px;border-right-width:8px;}
+.border-y-0{border-top-width:0;border-bottom-width:0;}
+.border-y-2{border-top-width:2px;border-bottom-width:2px;}
+.border-y-4{border-top-width:4px;border-bottom-width:4px;}
+.border-y-8{border-top-width:8px;border-bottom-width:8px;}"
+`;
+
+exports[`rounded > supports x|y with value 1`] = `
+"/* layer: default */
+.rounded,
+.rounded-4{border-radius:4px;}
+.rounded-0{border-radius:0;}
+.rounded-16{border-radius:16px;}
+.rounded-2{border-radius:2px;}
+.rounded-8{border-radius:8px;}
+.rounded-full{border-radius:9999px;}
+.rounded-b,
+.rounded-b-4{border-bottom-left-radius:4px;border-bottom-right-radius:4px;}
+.rounded-b-0{border-bottom-left-radius:0;border-bottom-right-radius:0;}
+.rounded-b-16{border-bottom-left-radius:16px;border-bottom-right-radius:16px;}
+.rounded-b-2{border-bottom-left-radius:2px;border-bottom-right-radius:2px;}
+.rounded-b-8{border-bottom-left-radius:8px;border-bottom-right-radius:8px;}
+.rounded-b-full{border-bottom-left-radius:9999px;border-bottom-right-radius:9999px;}
+.rounded-bl-0{border-bottom-left-radius:0;}
+.rounded-bl-16{border-bottom-left-radius:16px;}
+.rounded-bl-2{border-bottom-left-radius:2px;}
+.rounded-bl-4{border-bottom-left-radius:4px;}
+.rounded-bl-8{border-bottom-left-radius:8px;}
+.rounded-bl-full{border-bottom-left-radius:9999px;}
+.rounded-br-0{border-bottom-right-radius:0;}
+.rounded-br-16{border-bottom-right-radius:16px;}
+.rounded-br-2{border-bottom-right-radius:2px;}
+.rounded-br-4{border-bottom-right-radius:4px;}
+.rounded-br-8{border-bottom-right-radius:8px;}
+.rounded-br-full{border-bottom-right-radius:9999px;}
+.rounded-l,
+.rounded-l-4{border-top-left-radius:4px;border-bottom-left-radius:4px;}
+.rounded-l-0{border-top-left-radius:0;border-bottom-left-radius:0;}
+.rounded-l-16{border-top-left-radius:16px;border-bottom-left-radius:16px;}
+.rounded-l-2{border-top-left-radius:2px;border-bottom-left-radius:2px;}
+.rounded-l-8{border-top-left-radius:8px;border-bottom-left-radius:8px;}
+.rounded-l-full{border-top-left-radius:9999px;border-bottom-left-radius:9999px;}
+.rounded-r,
+.rounded-r-4{border-top-right-radius:4px;border-bottom-right-radius:4px;}
+.rounded-r-0{border-top-right-radius:0;border-bottom-right-radius:0;}
+.rounded-r-16{border-top-right-radius:16px;border-bottom-right-radius:16px;}
+.rounded-r-2{border-top-right-radius:2px;border-bottom-right-radius:2px;}
+.rounded-r-8{border-top-right-radius:8px;border-bottom-right-radius:8px;}
+.rounded-r-full{border-top-right-radius:9999px;border-bottom-right-radius:9999px;}
+.rounded-t,
+.rounded-t-4{border-top-left-radius:4px;border-top-right-radius:4px;}
+.rounded-t-0{border-top-left-radius:0;border-top-right-radius:0;}
+.rounded-t-16{border-top-left-radius:16px;border-top-right-radius:16px;}
+.rounded-t-2{border-top-left-radius:2px;border-top-right-radius:2px;}
+.rounded-t-8{border-top-left-radius:8px;border-top-right-radius:8px;}
+.rounded-t-full{border-top-left-radius:9999px;border-top-right-radius:9999px;}
+.rounded-tl-0{border-top-left-radius:0;}
+.rounded-tl-16{border-top-left-radius:16px;}
+.rounded-tl-2{border-top-left-radius:2px;}
+.rounded-tl-4{border-top-left-radius:4px;}
+.rounded-tl-8{border-top-left-radius:8px;}
+.rounded-tl-full{border-top-left-radius:9999px;}
+.rounded-tr-0{border-top-right-radius:0;}
+.rounded-tr-16{border-top-right-radius:16px;}
+.rounded-tr-2{border-top-right-radius:2px;}
+.rounded-tr-4{border-top-right-radius:4px;}
+.rounded-tr-8{border-top-right-radius:8px;}
+.rounded-tr-full{border-top-right-radius:9999px;}"
+`;

--- a/plugin/test/border.js
+++ b/plugin/test/border.js
@@ -14,14 +14,14 @@ describe("border", () => {
 
     expect(css).toMatchInlineSnapshot(`
       "/* layer: default */
-      .border-x-0{border-left-width:0px;border-right-width:0px;border-left-style:solid;border-right-style:solid;}
-      .border-x-2{border-left-width:2px;border-right-width:2px;border-left-style:solid;border-right-style:solid;}
-      .border-x-4{border-left-width:4px;border-right-width:4px;border-left-style:solid;border-right-style:solid;}
-      .border-x-8{border-left-width:8px;border-right-width:8px;border-left-style:solid;border-right-style:solid;}
-      .border-y-0{border-top-width:0px;border-bottom-width:0px;border-top-style:solid;border-bottom-style:solid;}
-      .border-y-2{border-top-width:2px;border-bottom-width:2px;border-top-style:solid;border-bottom-style:solid;}
-      .border-y-4{border-top-width:4px;border-bottom-width:4px;border-top-style:solid;border-bottom-style:solid;}
-      .border-y-8{border-top-width:8px;border-bottom-width:8px;border-top-style:solid;border-bottom-style:solid;}"
+      .border-x-0{border-left-width:0px;border-right-width:0px;}
+      .border-x-2{border-left-width:2px;border-right-width:2px;}
+      .border-x-4{border-left-width:4px;border-right-width:4px;}
+      .border-x-8{border-left-width:8px;border-right-width:8px;}
+      .border-y-0{border-top-width:0px;border-bottom-width:0px;}
+      .border-y-2{border-top-width:2px;border-bottom-width:2px;}
+      .border-y-4{border-top-width:4px;border-bottom-width:4px;}
+      .border-y-8{border-top-width:8px;border-bottom-width:8px;}"
     `);
   });
 
@@ -32,11 +32,11 @@ describe("border", () => {
 
     expect(css).toMatchInlineSnapshot(`
       "/* layer: default */
-      .border{border-width:1px;border-style:solid;}
-      .border-0{border-width:0px;border-style:solid;}
-      .border-2{border-width:2px;border-style:solid;}
-      .border-4{border-width:4px;border-style:solid;}
-      .border-8{border-width:8px;border-style:solid;}"
+      .border{border-width:1px;}
+      .border-0{border-width:0px;}
+      .border-2{border-width:2px;}
+      .border-4{border-width:4px;}
+      .border-8{border-width:8px;}"
     `);
   });
 
@@ -110,26 +110,26 @@ describe("border", () => {
 
     expect(css).toMatchInlineSnapshot(`
       "/* layer: default */
-      .border-b{border-bottom-width:1px;border-bottom-style:solid;}
-      .border-l{border-left-width:1px;border-left-style:solid;}
-      .border-r{border-right-width:1px;border-right-style:solid;}
-      .border-t{border-top-width:1px;border-top-style:solid;}
-      .border-b-0{border-bottom-width:0px;border-bottom-style:solid;}
-      .border-b-2{border-bottom-width:2px;border-bottom-style:solid;}
-      .border-b-4{border-bottom-width:4px;border-bottom-style:solid;}
-      .border-b-8{border-bottom-width:8px;border-bottom-style:solid;}
-      .border-l-0{border-left-width:0px;border-left-style:solid;}
-      .border-l-2{border-left-width:2px;border-left-style:solid;}
-      .border-l-4{border-left-width:4px;border-left-style:solid;}
-      .border-l-8{border-left-width:8px;border-left-style:solid;}
-      .border-r-0{border-right-width:0px;border-right-style:solid;}
-      .border-r-2{border-right-width:2px;border-right-style:solid;}
-      .border-r-4{border-right-width:4px;border-right-style:solid;}
-      .border-r-8{border-right-width:8px;border-right-style:solid;}
-      .border-t-0{border-top-width:0px;border-top-style:solid;}
-      .border-t-2{border-top-width:2px;border-top-style:solid;}
-      .border-t-4{border-top-width:4px;border-top-style:solid;}
-      .border-t-8{border-top-width:8px;border-top-style:solid;}"
+      .border-b{border-bottom-width:1px;}
+      .border-l{border-left-width:1px;}
+      .border-r{border-right-width:1px;}
+      .border-t{border-top-width:1px;}
+      .border-b-0{border-bottom-width:0px;}
+      .border-b-2{border-bottom-width:2px;}
+      .border-b-4{border-bottom-width:4px;}
+      .border-b-8{border-bottom-width:8px;}
+      .border-l-0{border-left-width:0px;}
+      .border-l-2{border-left-width:2px;}
+      .border-l-4{border-left-width:4px;}
+      .border-l-8{border-left-width:8px;}
+      .border-r-0{border-right-width:0px;}
+      .border-r-2{border-right-width:2px;}
+      .border-r-4{border-right-width:4px;}
+      .border-r-8{border-right-width:8px;}
+      .border-t-0{border-top-width:0px;}
+      .border-t-2{border-top-width:2px;}
+      .border-t-4{border-top-width:4px;}
+      .border-t-8{border-top-width:8px;}"
     `);
   });
 });

--- a/plugin/test/border.js
+++ b/plugin/test/border.js
@@ -12,17 +12,7 @@ describe("border", () => {
 
     const { css } = await t.uno.generate(classes);
 
-    expect(css).toMatchInlineSnapshot(`
-      "/* layer: default */
-      .border-x-0{border-left-width:0;border-right-width:0;}
-      .border-x-2{border-left-width:2px;border-right-width:2px;}
-      .border-x-4{border-left-width:4px;border-right-width:4px;}
-      .border-x-8{border-left-width:8px;border-right-width:8px;}
-      .border-y-0{border-top-width:0;border-bottom-width:0;}
-      .border-y-2{border-top-width:2px;border-bottom-width:2px;}
-      .border-y-4{border-top-width:4px;border-bottom-width:4px;}
-      .border-y-8{border-top-width:8px;border-bottom-width:8px;}"
-    `);
+    expect(css).toMatchSnapshot();
   });
 
   test("supports setting border width", async (t) => {
@@ -30,14 +20,7 @@ describe("border", () => {
 
     const { css } = await t.uno.generate(classes);
 
-    expect(css).toMatchInlineSnapshot(`
-      "/* layer: default */
-      .border,
-      .border-2{border-width:2px;}
-      .border-0{border-width:0;}
-      .border-4{border-width:4px;}
-      .border-8{border-width:8px;}"
-    `);
+    expect(css).toMatchSnapshot();
   });
 
   test("supports setting border style", async (t) => {
@@ -56,19 +39,7 @@ describe("border", () => {
 
     const { css } = await t.uno.generate(classes);
 
-    expect(css).toMatchInlineSnapshot(`
-      "/* layer: default */
-      .border-dashed{border-style:dashed;}
-      .border-dotted{border-style:dotted;}
-      .border-double{border-style:double;}
-      .border-groove{border-style:groove;}
-      .border-hidden{border-style:hidden;}
-      .border-inset{border-style:inset;}
-      .border-none{border-style:none;}
-      .border-outset{border-style:outset;}
-      .border-ridge{border-style:ridge;}
-      .border-solid{border-style:solid;}"
-    `);
+    expect(css).toMatchSnapshot();
   });
 
   test("right, left, top bottom", async (t) => {
@@ -108,29 +79,7 @@ describe("border", () => {
 
     const { css } = await t.uno.generate(classes);
 
-    expect(css).toMatchInlineSnapshot(`
-      "/* layer: default */
-      .border-b,
-      .border-b-2{border-bottom-width:2px;}
-      .border-l,
-      .border-l-2{border-left-width:2px;}
-      .border-r,
-      .border-r-2{border-right-width:2px;}
-      .border-t,
-      .border-t-2{border-top-width:2px;}
-      .border-b-0{border-bottom-width:0;}
-      .border-b-4{border-bottom-width:4px;}
-      .border-b-8{border-bottom-width:8px;}
-      .border-l-0{border-left-width:0;}
-      .border-l-4{border-left-width:4px;}
-      .border-l-8{border-left-width:8px;}
-      .border-r-0{border-right-width:0;}
-      .border-r-4{border-right-width:4px;}
-      .border-r-8{border-right-width:8px;}
-      .border-t-0{border-top-width:0;}
-      .border-t-4{border-top-width:4px;}
-      .border-t-8{border-top-width:8px;}"
-    `);
+    expect(css).toMatchSnapshot();
   });
 });
 
@@ -140,67 +89,6 @@ describe("rounded", () => {
 
     const { css } = await t.uno.generate(classes);
 
-    expect(css).toMatchInlineSnapshot(`
-      "/* layer: default */
-      .rounded,
-      .rounded-2{border-radius:2px;}
-      .rounded-0{border-radius:0;}
-      .rounded-16{border-radius:16px;}
-      .rounded-4{border-radius:4px;}
-      .rounded-8{border-radius:8px;}
-      .rounded-full{border-radius:9999px;}
-      .rounded-b,
-      .rounded-b-2{border-bottom-left-radius:2px;border-bottom-right-radius:2px;}
-      .rounded-b-0{border-bottom-left-radius:0;border-bottom-right-radius:0;}
-      .rounded-b-16{border-bottom-left-radius:16px;border-bottom-right-radius:16px;}
-      .rounded-b-4{border-bottom-left-radius:4px;border-bottom-right-radius:4px;}
-      .rounded-b-8{border-bottom-left-radius:8px;border-bottom-right-radius:8px;}
-      .rounded-b-full{border-bottom-left-radius:9999px;border-bottom-right-radius:9999px;}
-      .rounded-bl-0{border-bottom-left-radius:0;}
-      .rounded-bl-16{border-bottom-left-radius:16px;}
-      .rounded-bl-2{border-bottom-left-radius:2px;}
-      .rounded-bl-4{border-bottom-left-radius:4px;}
-      .rounded-bl-8{border-bottom-left-radius:8px;}
-      .rounded-bl-full{border-bottom-left-radius:9999px;}
-      .rounded-br-0{border-bottom-right-radius:0;}
-      .rounded-br-16{border-bottom-right-radius:16px;}
-      .rounded-br-2{border-bottom-right-radius:2px;}
-      .rounded-br-4{border-bottom-right-radius:4px;}
-      .rounded-br-8{border-bottom-right-radius:8px;}
-      .rounded-br-full{border-bottom-right-radius:9999px;}
-      .rounded-l,
-      .rounded-l-2{border-top-left-radius:2px;border-bottom-left-radius:2px;}
-      .rounded-l-0{border-top-left-radius:0;border-bottom-left-radius:0;}
-      .rounded-l-16{border-top-left-radius:16px;border-bottom-left-radius:16px;}
-      .rounded-l-4{border-top-left-radius:4px;border-bottom-left-radius:4px;}
-      .rounded-l-8{border-top-left-radius:8px;border-bottom-left-radius:8px;}
-      .rounded-l-full{border-top-left-radius:9999px;border-bottom-left-radius:9999px;}
-      .rounded-r,
-      .rounded-r-2{border-top-right-radius:2px;border-bottom-right-radius:2px;}
-      .rounded-r-0{border-top-right-radius:0;border-bottom-right-radius:0;}
-      .rounded-r-16{border-top-right-radius:16px;border-bottom-right-radius:16px;}
-      .rounded-r-4{border-top-right-radius:4px;border-bottom-right-radius:4px;}
-      .rounded-r-8{border-top-right-radius:8px;border-bottom-right-radius:8px;}
-      .rounded-r-full{border-top-right-radius:9999px;border-bottom-right-radius:9999px;}
-      .rounded-t,
-      .rounded-t-2{border-top-left-radius:2px;border-top-right-radius:2px;}
-      .rounded-t-0{border-top-left-radius:0;border-top-right-radius:0;}
-      .rounded-t-16{border-top-left-radius:16px;border-top-right-radius:16px;}
-      .rounded-t-4{border-top-left-radius:4px;border-top-right-radius:4px;}
-      .rounded-t-8{border-top-left-radius:8px;border-top-right-radius:8px;}
-      .rounded-t-full{border-top-left-radius:9999px;border-top-right-radius:9999px;}
-      .rounded-tl-0{border-top-left-radius:0;}
-      .rounded-tl-16{border-top-left-radius:16px;}
-      .rounded-tl-2{border-top-left-radius:2px;}
-      .rounded-tl-4{border-top-left-radius:4px;}
-      .rounded-tl-8{border-top-left-radius:8px;}
-      .rounded-tl-full{border-top-left-radius:9999px;}
-      .rounded-tr-0{border-top-right-radius:0;}
-      .rounded-tr-16{border-top-right-radius:16px;}
-      .rounded-tr-2{border-top-right-radius:2px;}
-      .rounded-tr-4{border-top-right-radius:4px;}
-      .rounded-tr-8{border-top-right-radius:8px;}
-      .rounded-tr-full{border-top-right-radius:9999px;}"
-    `);
+    expect(css).toMatchSnapshot();
   });
 });

--- a/plugin/test/border.js
+++ b/plugin/test/border.js
@@ -133,3 +133,69 @@ describe("border", () => {
     `);
   });
 });
+
+describe("rounded", () => {
+  test("supports x|y with value", async (t) => {
+    const classes = ["rounded-0", "rounded-2", "rounded-4", "rounded-8", "rounded-16", "rounded-full", "rounded-t-0", "rounded-t-2", "rounded-t-4", "rounded-t-8", "rounded-t-16", "rounded-t-full", "rounded-r-0", "rounded-r-2", "rounded-r-4", "rounded-r-8", "rounded-r-16", "rounded-r-full", "rounded-b-0", "rounded-b-2", "rounded-b-4", "rounded-b-8", "rounded-b-16", "rounded-b-full", "rounded-l-0", "rounded-l-2", "rounded-l-4", "rounded-l-8", "rounded-l-16", "rounded-l-full", "rounded-tl-0", "rounded-tl-2", "rounded-tl-4", "rounded-tl-8", "rounded-tl-16", "rounded-tl-full", "rounded-tr-0", "rounded-tr-2", "rounded-tr-4", "rounded-tr-8", "rounded-tr-16", "rounded-tr-full", "rounded-br-0", "rounded-br-2", "rounded-br-4", "rounded-br-8", "rounded-br-16", "rounded-br-full", "rounded-bl-0", "rounded-bl-2", "rounded-bl-4", "rounded-bl-8", "rounded-bl-16", "rounded-bl-full"];
+
+    const { css } = await t.uno.generate(classes);
+
+    expect(css).toMatchInlineSnapshot(`
+      "/* layer: default */
+      .rounded-0{border-radius:0rem;}
+      .rounded-16{border-radius:1.6rem;}
+      .rounded-2{border-radius:0.2rem;}
+      .rounded-4{border-radius:0.4rem;}
+      .rounded-8{border-radius:0.8rem;}
+      .rounded-full{border-radius:100%;}
+      .rounded-b-0{border-bottom-left-radius:0rem;border-bottom-right-radius:0rem;}
+      .rounded-b-16{border-bottom-left-radius:1.6rem;border-bottom-right-radius:1.6rem;}
+      .rounded-b-2{border-bottom-left-radius:0.2rem;border-bottom-right-radius:0.2rem;}
+      .rounded-b-4{border-bottom-left-radius:0.4rem;border-bottom-right-radius:0.4rem;}
+      .rounded-b-8{border-bottom-left-radius:0.8rem;border-bottom-right-radius:0.8rem;}
+      .rounded-b-full{border-bottom-left-radius:100%;border-bottom-right-radius:100%;}
+      .rounded-bl-0{border-bottom-left-radius:0rem;}
+      .rounded-bl-16{border-bottom-left-radius:1.6rem;}
+      .rounded-bl-2{border-bottom-left-radius:0.2rem;}
+      .rounded-bl-4{border-bottom-left-radius:0.4rem;}
+      .rounded-bl-8{border-bottom-left-radius:0.8rem;}
+      .rounded-bl-full{border-bottom-left-radius:100%;}
+      .rounded-br-0{border-bottom-right-radius:0rem;}
+      .rounded-br-16{border-bottom-right-radius:1.6rem;}
+      .rounded-br-2{border-bottom-right-radius:0.2rem;}
+      .rounded-br-4{border-bottom-right-radius:0.4rem;}
+      .rounded-br-8{border-bottom-right-radius:0.8rem;}
+      .rounded-br-full{border-bottom-right-radius:100%;}
+      .rounded-l-0{border-top-left-radius:0rem;border-bottom-left-radius:0rem;}
+      .rounded-l-16{border-top-left-radius:1.6rem;border-bottom-left-radius:1.6rem;}
+      .rounded-l-2{border-top-left-radius:0.2rem;border-bottom-left-radius:0.2rem;}
+      .rounded-l-4{border-top-left-radius:0.4rem;border-bottom-left-radius:0.4rem;}
+      .rounded-l-8{border-top-left-radius:0.8rem;border-bottom-left-radius:0.8rem;}
+      .rounded-l-full{border-top-left-radius:100%;border-bottom-left-radius:100%;}
+      .rounded-r-0{border-top-right-radius:0rem;border-bottom-right-radius:0rem;}
+      .rounded-r-16{border-top-right-radius:1.6rem;border-bottom-right-radius:1.6rem;}
+      .rounded-r-2{border-top-right-radius:0.2rem;border-bottom-right-radius:0.2rem;}
+      .rounded-r-4{border-top-right-radius:0.4rem;border-bottom-right-radius:0.4rem;}
+      .rounded-r-8{border-top-right-radius:0.8rem;border-bottom-right-radius:0.8rem;}
+      .rounded-r-full{border-top-right-radius:100%;border-bottom-right-radius:100%;}
+      .rounded-t-0{border-top-left-radius:0rem;border-top-right-radius:0rem;}
+      .rounded-t-16{border-top-left-radius:1.6rem;border-top-right-radius:1.6rem;}
+      .rounded-t-2{border-top-left-radius:0.2rem;border-top-right-radius:0.2rem;}
+      .rounded-t-4{border-top-left-radius:0.4rem;border-top-right-radius:0.4rem;}
+      .rounded-t-8{border-top-left-radius:0.8rem;border-top-right-radius:0.8rem;}
+      .rounded-t-full{border-top-left-radius:100%;border-top-right-radius:100%;}
+      .rounded-tl-0{border-top-left-radius:0rem;}
+      .rounded-tl-16{border-top-left-radius:1.6rem;}
+      .rounded-tl-2{border-top-left-radius:0.2rem;}
+      .rounded-tl-4{border-top-left-radius:0.4rem;}
+      .rounded-tl-8{border-top-left-radius:0.8rem;}
+      .rounded-tl-full{border-top-left-radius:100%;}
+      .rounded-tr-0{border-top-right-radius:0rem;}
+      .rounded-tr-16{border-top-right-radius:1.6rem;}
+      .rounded-tr-2{border-top-right-radius:0.2rem;}
+      .rounded-tr-4{border-top-right-radius:0.4rem;}
+      .rounded-tr-8{border-top-right-radius:0.8rem;}
+      .rounded-tr-full{border-top-right-radius:100%;}"
+    `);
+  });
+});

--- a/plugin/test/border.js
+++ b/plugin/test/border.js
@@ -1,0 +1,135 @@
+import { setup } from "./_helpers.js";
+import { describe, expect, test } from "vitest";
+
+setup();
+
+describe("border", () => {
+  test("supports x|y with value", async (t) => {
+    const x = ["border-x-0", "border-x-2", "border-x-4", "border-x-8"];
+    const y = ["border-y-0", "border-y-2", "border-y-4", "border-y-8"];
+
+    const classes = [...x, ...y];
+
+    const { css } = await t.uno.generate(classes);
+
+    expect(css).toMatchInlineSnapshot(`
+      "/* layer: default */
+      .border-x-0{border-left-width:0px;border-right-width:0px;border-left-style:solid;border-right-style:solid;}
+      .border-x-2{border-left-width:2px;border-right-width:2px;border-left-style:solid;border-right-style:solid;}
+      .border-x-4{border-left-width:4px;border-right-width:4px;border-left-style:solid;border-right-style:solid;}
+      .border-x-8{border-left-width:8px;border-right-width:8px;border-left-style:solid;border-right-style:solid;}
+      .border-y-0{border-top-width:0px;border-bottom-width:0px;border-top-style:solid;border-bottom-style:solid;}
+      .border-y-2{border-top-width:2px;border-bottom-width:2px;border-top-style:solid;border-bottom-style:solid;}
+      .border-y-4{border-top-width:4px;border-bottom-width:4px;border-top-style:solid;border-bottom-style:solid;}
+      .border-y-8{border-top-width:8px;border-bottom-width:8px;border-top-style:solid;border-bottom-style:solid;}"
+    `);
+  });
+
+  test("supports setting border width", async (t) => {
+    const classes = ["border", "border-0", "border-2", "border-4", "border-8"];
+
+    const { css } = await t.uno.generate(classes);
+
+    expect(css).toMatchInlineSnapshot(`
+      "/* layer: default */
+      .border{border-width:1px;border-style:solid;}
+      .border-0{border-width:0px;border-style:solid;}
+      .border-2{border-width:2px;border-style:solid;}
+      .border-4{border-width:4px;border-style:solid;}
+      .border-8{border-width:8px;border-style:solid;}"
+    `);
+  });
+
+  test("supports setting border style", async (t) => {
+    const classes = [
+      "border-solid",
+      "border-dashed",
+      "border-dotted",
+      "border-double",
+      "border-hidden",
+      "border-none",
+      "border-groove",
+      "border-ridge",
+      "border-inset",
+      "border-outset",
+    ];
+
+    const { css } = await t.uno.generate(classes);
+
+    expect(css).toMatchInlineSnapshot(`
+      "/* layer: default */
+      .border-dashed{border-style:dashed;}
+      .border-dotted{border-style:dotted;}
+      .border-double{border-style:double;}
+      .border-groove{border-style:groove;}
+      .border-hidden{border-style:hidden;}
+      .border-inset{border-style:inset;}
+      .border-none{border-style:none;}
+      .border-outset{border-style:outset;}
+      .border-ridge{border-style:ridge;}
+      .border-solid{border-style:solid;}"
+    `);
+  });
+
+  test("right, left, top bottom", async (t) => {
+    const right = [
+      "border-r",
+      "border-r-0",
+      "border-r-2",
+      "border-r-4",
+      "border-r-8",
+    ];
+
+    const left = [
+      "border-l",
+      "border-l-0",
+      "border-l-2",
+      "border-l-4",
+      "border-l-8",
+    ];
+
+    const top = [
+      "border-t",
+      "border-t-0",
+      "border-t-2",
+      "border-t-4",
+      "border-t-8",
+    ];
+
+    const bottom = [
+      "border-b",
+      "border-b-0",
+      "border-b-2",
+      "border-b-4",
+      "border-b-8",
+    ];
+
+    const classes = [...right, ...left, ...top, ...bottom];
+
+    const { css } = await t.uno.generate(classes);
+
+    expect(css).toMatchInlineSnapshot(`
+      "/* layer: default */
+      .border-b{border-bottom-width:1px;border-bottom-style:solid;}
+      .border-l{border-left-width:1px;border-left-style:solid;}
+      .border-r{border-right-width:1px;border-right-style:solid;}
+      .border-t{border-top-width:1px;border-top-style:solid;}
+      .border-b-0{border-bottom-width:0px;border-bottom-style:solid;}
+      .border-b-2{border-bottom-width:2px;border-bottom-style:solid;}
+      .border-b-4{border-bottom-width:4px;border-bottom-style:solid;}
+      .border-b-8{border-bottom-width:8px;border-bottom-style:solid;}
+      .border-l-0{border-left-width:0px;border-left-style:solid;}
+      .border-l-2{border-left-width:2px;border-left-style:solid;}
+      .border-l-4{border-left-width:4px;border-left-style:solid;}
+      .border-l-8{border-left-width:8px;border-left-style:solid;}
+      .border-r-0{border-right-width:0px;border-right-style:solid;}
+      .border-r-2{border-right-width:2px;border-right-style:solid;}
+      .border-r-4{border-right-width:4px;border-right-style:solid;}
+      .border-r-8{border-right-width:8px;border-right-style:solid;}
+      .border-t-0{border-top-width:0px;border-top-style:solid;}
+      .border-t-2{border-top-width:2px;border-top-style:solid;}
+      .border-t-4{border-top-width:4px;border-top-style:solid;}
+      .border-t-8{border-top-width:8px;border-top-style:solid;}"
+    `);
+  });
+});

--- a/plugin/test/border.js
+++ b/plugin/test/border.js
@@ -14,11 +14,11 @@ describe("border", () => {
 
     expect(css).toMatchInlineSnapshot(`
       "/* layer: default */
-      .border-x-0{border-left-width:0px;border-right-width:0px;}
+      .border-x-0{border-left-width:0;border-right-width:0;}
       .border-x-2{border-left-width:2px;border-right-width:2px;}
       .border-x-4{border-left-width:4px;border-right-width:4px;}
       .border-x-8{border-left-width:8px;border-right-width:8px;}
-      .border-y-0{border-top-width:0px;border-bottom-width:0px;}
+      .border-y-0{border-top-width:0;border-bottom-width:0;}
       .border-y-2{border-top-width:2px;border-bottom-width:2px;}
       .border-y-4{border-top-width:4px;border-bottom-width:4px;}
       .border-y-8{border-top-width:8px;border-bottom-width:8px;}"
@@ -32,9 +32,9 @@ describe("border", () => {
 
     expect(css).toMatchInlineSnapshot(`
       "/* layer: default */
-      .border{border-width:1px;}
-      .border-0{border-width:0px;}
+      .border,
       .border-2{border-width:2px;}
+      .border-0{border-width:0;}
       .border-4{border-width:4px;}
       .border-8{border-width:8px;}"
     `);
@@ -110,24 +110,24 @@ describe("border", () => {
 
     expect(css).toMatchInlineSnapshot(`
       "/* layer: default */
-      .border-b{border-bottom-width:1px;}
-      .border-l{border-left-width:1px;}
-      .border-r{border-right-width:1px;}
-      .border-t{border-top-width:1px;}
-      .border-b-0{border-bottom-width:0px;}
+      .border-b,
       .border-b-2{border-bottom-width:2px;}
+      .border-l,
+      .border-l-2{border-left-width:2px;}
+      .border-r,
+      .border-r-2{border-right-width:2px;}
+      .border-t,
+      .border-t-2{border-top-width:2px;}
+      .border-b-0{border-bottom-width:0;}
       .border-b-4{border-bottom-width:4px;}
       .border-b-8{border-bottom-width:8px;}
-      .border-l-0{border-left-width:0px;}
-      .border-l-2{border-left-width:2px;}
+      .border-l-0{border-left-width:0;}
       .border-l-4{border-left-width:4px;}
       .border-l-8{border-left-width:8px;}
-      .border-r-0{border-right-width:0px;}
-      .border-r-2{border-right-width:2px;}
+      .border-r-0{border-right-width:0;}
       .border-r-4{border-right-width:4px;}
       .border-r-8{border-right-width:8px;}
-      .border-t-0{border-top-width:0px;}
-      .border-t-2{border-top-width:2px;}
+      .border-t-0{border-top-width:0;}
       .border-t-4{border-top-width:4px;}
       .border-t-8{border-top-width:8px;}"
     `);
@@ -136,66 +136,71 @@ describe("border", () => {
 
 describe("rounded", () => {
   test("supports x|y with value", async (t) => {
-    const classes = ["rounded-0", "rounded-2", "rounded-4", "rounded-8", "rounded-16", "rounded-full", "rounded-t-0", "rounded-t-2", "rounded-t-4", "rounded-t-8", "rounded-t-16", "rounded-t-full", "rounded-r-0", "rounded-r-2", "rounded-r-4", "rounded-r-8", "rounded-r-16", "rounded-r-full", "rounded-b-0", "rounded-b-2", "rounded-b-4", "rounded-b-8", "rounded-b-16", "rounded-b-full", "rounded-l-0", "rounded-l-2", "rounded-l-4", "rounded-l-8", "rounded-l-16", "rounded-l-full", "rounded-tl-0", "rounded-tl-2", "rounded-tl-4", "rounded-tl-8", "rounded-tl-16", "rounded-tl-full", "rounded-tr-0", "rounded-tr-2", "rounded-tr-4", "rounded-tr-8", "rounded-tr-16", "rounded-tr-full", "rounded-br-0", "rounded-br-2", "rounded-br-4", "rounded-br-8", "rounded-br-16", "rounded-br-full", "rounded-bl-0", "rounded-bl-2", "rounded-bl-4", "rounded-bl-8", "rounded-bl-16", "rounded-bl-full"];
+    const classes = ["rounded", "rounded-0", "rounded-2", "rounded-4", "rounded-8", "rounded-16", "rounded-full", "rounded-t", "rounded-t-0", "rounded-t-2", "rounded-t-4", "rounded-t-8", "rounded-t-16", "rounded-t-full", "rounded-r", "rounded-r-0", "rounded-r-2", "rounded-r-4", "rounded-r-8", "rounded-r-16", "rounded-r-full", "rounded-b", "rounded-b-0", "rounded-b-2", "rounded-b-4", "rounded-b-8", "rounded-b-16", "rounded-b-full", "rounded-l", "rounded-l-0", "rounded-l-2", "rounded-l-4", "rounded-l-8", "rounded-l-16", "rounded-l-full", "rounded-tl-0", "rounded-tl-2", "rounded-tl-4", "rounded-tl-8", "rounded-tl-16", "rounded-tl-full", "rounded-tr-0", "rounded-tr-2", "rounded-tr-4", "rounded-tr-8", "rounded-tr-16", "rounded-tr-full", "rounded-br-0", "rounded-br-2", "rounded-br-4", "rounded-br-8", "rounded-br-16", "rounded-br-full", "rounded-bl-0", "rounded-bl-2", "rounded-bl-4", "rounded-bl-8", "rounded-bl-16", "rounded-bl-full"];
 
     const { css } = await t.uno.generate(classes);
 
     expect(css).toMatchInlineSnapshot(`
       "/* layer: default */
-      .rounded-0{border-radius:0rem;}
-      .rounded-16{border-radius:1.6rem;}
-      .rounded-2{border-radius:0.2rem;}
-      .rounded-4{border-radius:0.4rem;}
-      .rounded-8{border-radius:0.8rem;}
-      .rounded-full{border-radius:100%;}
-      .rounded-b-0{border-bottom-left-radius:0rem;border-bottom-right-radius:0rem;}
-      .rounded-b-16{border-bottom-left-radius:1.6rem;border-bottom-right-radius:1.6rem;}
-      .rounded-b-2{border-bottom-left-radius:0.2rem;border-bottom-right-radius:0.2rem;}
-      .rounded-b-4{border-bottom-left-radius:0.4rem;border-bottom-right-radius:0.4rem;}
-      .rounded-b-8{border-bottom-left-radius:0.8rem;border-bottom-right-radius:0.8rem;}
-      .rounded-b-full{border-bottom-left-radius:100%;border-bottom-right-radius:100%;}
-      .rounded-bl-0{border-bottom-left-radius:0rem;}
-      .rounded-bl-16{border-bottom-left-radius:1.6rem;}
-      .rounded-bl-2{border-bottom-left-radius:0.2rem;}
-      .rounded-bl-4{border-bottom-left-radius:0.4rem;}
-      .rounded-bl-8{border-bottom-left-radius:0.8rem;}
-      .rounded-bl-full{border-bottom-left-radius:100%;}
-      .rounded-br-0{border-bottom-right-radius:0rem;}
-      .rounded-br-16{border-bottom-right-radius:1.6rem;}
-      .rounded-br-2{border-bottom-right-radius:0.2rem;}
-      .rounded-br-4{border-bottom-right-radius:0.4rem;}
-      .rounded-br-8{border-bottom-right-radius:0.8rem;}
-      .rounded-br-full{border-bottom-right-radius:100%;}
-      .rounded-l-0{border-top-left-radius:0rem;border-bottom-left-radius:0rem;}
-      .rounded-l-16{border-top-left-radius:1.6rem;border-bottom-left-radius:1.6rem;}
-      .rounded-l-2{border-top-left-radius:0.2rem;border-bottom-left-radius:0.2rem;}
-      .rounded-l-4{border-top-left-radius:0.4rem;border-bottom-left-radius:0.4rem;}
-      .rounded-l-8{border-top-left-radius:0.8rem;border-bottom-left-radius:0.8rem;}
-      .rounded-l-full{border-top-left-radius:100%;border-bottom-left-radius:100%;}
-      .rounded-r-0{border-top-right-radius:0rem;border-bottom-right-radius:0rem;}
-      .rounded-r-16{border-top-right-radius:1.6rem;border-bottom-right-radius:1.6rem;}
-      .rounded-r-2{border-top-right-radius:0.2rem;border-bottom-right-radius:0.2rem;}
-      .rounded-r-4{border-top-right-radius:0.4rem;border-bottom-right-radius:0.4rem;}
-      .rounded-r-8{border-top-right-radius:0.8rem;border-bottom-right-radius:0.8rem;}
-      .rounded-r-full{border-top-right-radius:100%;border-bottom-right-radius:100%;}
-      .rounded-t-0{border-top-left-radius:0rem;border-top-right-radius:0rem;}
-      .rounded-t-16{border-top-left-radius:1.6rem;border-top-right-radius:1.6rem;}
-      .rounded-t-2{border-top-left-radius:0.2rem;border-top-right-radius:0.2rem;}
-      .rounded-t-4{border-top-left-radius:0.4rem;border-top-right-radius:0.4rem;}
-      .rounded-t-8{border-top-left-radius:0.8rem;border-top-right-radius:0.8rem;}
-      .rounded-t-full{border-top-left-radius:100%;border-top-right-radius:100%;}
-      .rounded-tl-0{border-top-left-radius:0rem;}
-      .rounded-tl-16{border-top-left-radius:1.6rem;}
-      .rounded-tl-2{border-top-left-radius:0.2rem;}
-      .rounded-tl-4{border-top-left-radius:0.4rem;}
-      .rounded-tl-8{border-top-left-radius:0.8rem;}
-      .rounded-tl-full{border-top-left-radius:100%;}
-      .rounded-tr-0{border-top-right-radius:0rem;}
-      .rounded-tr-16{border-top-right-radius:1.6rem;}
-      .rounded-tr-2{border-top-right-radius:0.2rem;}
-      .rounded-tr-4{border-top-right-radius:0.4rem;}
-      .rounded-tr-8{border-top-right-radius:0.8rem;}
-      .rounded-tr-full{border-top-right-radius:100%;}"
+      .rounded,
+      .rounded-2{border-radius:2px;}
+      .rounded-0{border-radius:0;}
+      .rounded-16{border-radius:16px;}
+      .rounded-4{border-radius:4px;}
+      .rounded-8{border-radius:8px;}
+      .rounded-full{border-radius:9999px;}
+      .rounded-b,
+      .rounded-b-2{border-bottom-left-radius:2px;border-bottom-right-radius:2px;}
+      .rounded-b-0{border-bottom-left-radius:0;border-bottom-right-radius:0;}
+      .rounded-b-16{border-bottom-left-radius:16px;border-bottom-right-radius:16px;}
+      .rounded-b-4{border-bottom-left-radius:4px;border-bottom-right-radius:4px;}
+      .rounded-b-8{border-bottom-left-radius:8px;border-bottom-right-radius:8px;}
+      .rounded-b-full{border-bottom-left-radius:9999px;border-bottom-right-radius:9999px;}
+      .rounded-bl-0{border-bottom-left-radius:0;}
+      .rounded-bl-16{border-bottom-left-radius:16px;}
+      .rounded-bl-2{border-bottom-left-radius:2px;}
+      .rounded-bl-4{border-bottom-left-radius:4px;}
+      .rounded-bl-8{border-bottom-left-radius:8px;}
+      .rounded-bl-full{border-bottom-left-radius:9999px;}
+      .rounded-br-0{border-bottom-right-radius:0;}
+      .rounded-br-16{border-bottom-right-radius:16px;}
+      .rounded-br-2{border-bottom-right-radius:2px;}
+      .rounded-br-4{border-bottom-right-radius:4px;}
+      .rounded-br-8{border-bottom-right-radius:8px;}
+      .rounded-br-full{border-bottom-right-radius:9999px;}
+      .rounded-l,
+      .rounded-l-2{border-top-left-radius:2px;border-bottom-left-radius:2px;}
+      .rounded-l-0{border-top-left-radius:0;border-bottom-left-radius:0;}
+      .rounded-l-16{border-top-left-radius:16px;border-bottom-left-radius:16px;}
+      .rounded-l-4{border-top-left-radius:4px;border-bottom-left-radius:4px;}
+      .rounded-l-8{border-top-left-radius:8px;border-bottom-left-radius:8px;}
+      .rounded-l-full{border-top-left-radius:9999px;border-bottom-left-radius:9999px;}
+      .rounded-r,
+      .rounded-r-2{border-top-right-radius:2px;border-bottom-right-radius:2px;}
+      .rounded-r-0{border-top-right-radius:0;border-bottom-right-radius:0;}
+      .rounded-r-16{border-top-right-radius:16px;border-bottom-right-radius:16px;}
+      .rounded-r-4{border-top-right-radius:4px;border-bottom-right-radius:4px;}
+      .rounded-r-8{border-top-right-radius:8px;border-bottom-right-radius:8px;}
+      .rounded-r-full{border-top-right-radius:9999px;border-bottom-right-radius:9999px;}
+      .rounded-t,
+      .rounded-t-2{border-top-left-radius:2px;border-top-right-radius:2px;}
+      .rounded-t-0{border-top-left-radius:0;border-top-right-radius:0;}
+      .rounded-t-16{border-top-left-radius:16px;border-top-right-radius:16px;}
+      .rounded-t-4{border-top-left-radius:4px;border-top-right-radius:4px;}
+      .rounded-t-8{border-top-left-radius:8px;border-top-right-radius:8px;}
+      .rounded-t-full{border-top-left-radius:9999px;border-top-right-radius:9999px;}
+      .rounded-tl-0{border-top-left-radius:0;}
+      .rounded-tl-16{border-top-left-radius:16px;}
+      .rounded-tl-2{border-top-left-radius:2px;}
+      .rounded-tl-4{border-top-left-radius:4px;}
+      .rounded-tl-8{border-top-left-radius:8px;}
+      .rounded-tl-full{border-top-left-radius:9999px;}
+      .rounded-tr-0{border-top-right-radius:0;}
+      .rounded-tr-16{border-top-right-radius:16px;}
+      .rounded-tr-2{border-top-right-radius:2px;}
+      .rounded-tr-4{border-top-right-radius:4px;}
+      .rounded-tr-8{border-top-right-radius:8px;}
+      .rounded-tr-full{border-top-right-radius:9999px;}"
     `);
   });
 });


### PR DESCRIPTION
This adds rules for border and rounded classes, by the looks of it the added rules removes any related classes from the output of `checkFabricClasses.js`