### PR TITLE
Add outline and shadow classes to DEPRECATIONS.md

### DIFF
--- a/plugin/DEPRECATIONS.md
+++ b/plugin/DEPRECATIONS.md
@@ -1,0 +1,15 @@
+# These Fabric css rules will no longer be supported or need rethinking in Warp
+
+### Outline
+
+- outline-none
+- outline-white
+- outline-black
+
+### Shadow
+
+- shadow-2
+- shadow-3
+- shadow-4
+- shadow
+- shadow-none


### PR DESCRIPTION
This PR adds a markdown file we should populate with css classes that will probably no longer be supported in Warp Design System, or at least not in the same manner as in Fabric. We will then take a look at the full list and evaluate more in-depth how respective css rules should be handled.

Respective discussions on Slack:
- [about outline](https://sch-chat.slack.com/archives/C04LG5UTCTT/p1675342464480159)
- [about shadows](https://sch-chat.slack.com/archives/C04LG5UTCTT/p1675345388121489)