### PR TITLE
docs: correct relative path to parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # checking fabric classes
 
 1. Check out the `parity` project from warp-ds, get dependencies for the project
-2. Link to the `parity` project from the `plugin` folder (this folder): `pnpm link ../../parity`
+2. Link to the `parity` project from the `plugin` folder (this folder): `pnpm link ../parity`
 3. Run `node checkFabricClasses.js`


### PR DESCRIPTION
Minor change, change to correct path to parity in docs 🤷 