### PR TITLE
feat: add rules for focus-ring classes

### DIFF
--- a/src/_rules/focus-ring.js
+++ b/src/_rules/focus-ring.js
@@ -1,0 +1,16 @@
+// TODO: use actual variables and values when those has been defined
+const focusRingStyle = {
+  'outline': '2px solid var(--w-outline)',
+  'outline-offset': 'var(--w-outline-offset, 1px)',
+}
+
+const focusRingInsetStyle = {
+  '--w-outline-offset': '-3px',
+}
+
+export const focusRing = [
+  ["focusable:focus", focusRingStyle],
+  ["focusable:focus:not(:focus-visible)", { 'outline': 'none'}],
+  ["focusable:focus-visible", focusRingStyle],
+  ["focusable-inset", { ... focusRingInsetStyle }],
+];

--- a/src/_rules/index.js
+++ b/src/_rules/index.js
@@ -4,6 +4,7 @@ import * as border from "./border.js";
 import * as color from "./color.js";
 import * as display from "./display.js";
 import * as flex from "./flex.js";
+import * as focusRing from "./focus-ring.js";
 import * as gap from "./gap.js";
 import * as grid from "./grid.js";
 import * as layout from "./layout.js";
@@ -23,6 +24,7 @@ const ruleGroups = {
   ...color,
   ...display,
   ...flex,
+  ...focusRing,
   ...gap,
   ...grid,
   ...layout,
@@ -46,6 +48,7 @@ export * from "./border.js";
 export * from "./color.js";
 export * from "./display.js";
 export * from "./flex.js";
+export * from "./focus-ring.js";
 export * from "./gap.js";
 export * from "./grid.js";
 export * from "./layout.js";

--- a/test/focus-ring.js
+++ b/test/focus-ring.js
@@ -1,0 +1,23 @@
+import { expect, test } from 'vitest'
+import { setup } from "./_helpers.js";
+
+setup()
+
+test("focus ring", async (t) => {
+  const classes = [
+    "focusable:focus",
+    "focusable:focus:not(:focus-visible)",
+    "focusable:focus-visible",
+    "focusable-inset"
+  ]
+
+  const { css } = await t.uno.generate(classes)
+
+  expect(css).toMatchInlineSnapshot(`
+    "/* layer: default */
+    .focusable\\\\:focus,
+    .focusable\\\\:focus-visible{outline:2px solid var(--w-outline);outline-offset:var(--w-outline-offset, 1px);}
+    .focusable\\\\:focus\\\\:not\\\\(\\\\:focus-visible\\\\){outline:none;}
+    .focusable-inset{--w-outline-offset:-3px;}"
+  `)
+})


### PR DESCRIPTION
This adds rules for `focusable` classes which sets `outline` css