### PR TITLE
feat: add rules for text decoration

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -36,6 +36,11 @@ These are TW2 selectors, TW3 and other utility CSS have moved on in syntax.
 - ring-offset-transparent
 - ring-COLOR-*
 
+### Decoration
+
+- decoration-slice
+- decoration-clone
+
 ### Shadow
 
 - shadow-2

--- a/src/_rules/decoration.js
+++ b/src/_rules/decoration.js
@@ -1,0 +1,4 @@
+export const textDecorations = [
+    [/^(underline|line-through)$/, ([, s]) => ({ 'text-decoration-line': s })],
+    ['no-underline', { 'text-decoration': 'none' }],
+];

--- a/src/_rules/index.js
+++ b/src/_rules/index.js
@@ -3,6 +3,7 @@ import * as behaviors from "./behaviors.js";
 import * as border from "./border.js";
 import * as color from "./color.js";
 import * as display from "./display.js";
+import * as decoration from "./decoration.js";
 import * as flex from "./flex.js";
 import * as gap from "./gap.js";
 import * as grid from "./grid.js";
@@ -22,6 +23,7 @@ const ruleGroups = {
   ...border,
   ...color,
   ...display,
+  ...decoration,
   ...flex,
   ...gap,
   ...grid,
@@ -45,6 +47,7 @@ export * from "./behaviors.js";
 export * from "./border.js";
 export * from "./color.js";
 export * from "./display.js";
+export * from "./decoration.js";
 export * from "./flex.js";
 export * from "./gap.js";
 export * from "./grid.js";

--- a/test/__snapshots__/decoration.js.snap
+++ b/test/__snapshots__/decoration.js.snap
@@ -1,0 +1,12 @@
+// Vitest Snapshot v1
+
+exports[`text decoration > supports no-underline 1`] = `
+"/* layer: default */
+.no-underline{text-decoration:none;}"
+`;
+
+exports[`text decoration > supports underline and line-through 1`] = `
+"/* layer: default */
+.line-through{text-decoration-line:line-through;}
+.underline{text-decoration-line:underline;}"
+`;

--- a/test/decoration.js
+++ b/test/decoration.js
@@ -1,0 +1,22 @@
+import { setup } from "./_helpers.js";
+import { describe, expect, test } from "vitest";
+
+setup();
+
+describe("text decoration", () => {
+  test("supports underline and line-through", async (t) => {
+    const classes = ['underline', 'line-through']
+
+    const { css } = await t.uno.generate(classes);
+
+    expect(css).toMatchSnapshot();
+  });
+
+  test("supports no-underline", async (t) => {
+    const classes = ["no-underline"];
+
+    const { css } = await t.uno.generate(classes);
+
+    expect(css).toMatchSnapshot();
+  });
+})


### PR DESCRIPTION
Adds rules for `underline` `no-underline` and `line-through` decoration classes. 
Adds `decoration-slice` and `decoration-clone` to `DEPRECATIONS.md`
