### PR TITLE
Backport aspect ratio, set up the first internal classes

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -1,5 +1,13 @@
 # These Fabric css rules will no longer be supported or need rethinking in Warp
 
+### aspect ratio
+
+- aspect-w and aspect-h are deprecated in favor of the aspect-1/1 form
+- aspect-none - no support, not needed anymore since we have more responsive breakpoint support
+
+### focus ring
+- focus-ring :: prefer focusable
+
 ### Flex
 
 These are TW2 selectors, TW3 and other utility CSS have moved on in syntax.

--- a/dev.js
+++ b/dev.js
@@ -2,7 +2,7 @@ import { createGenerator } from '@unocss/core'
 import { presetWarp } from '#plugin'
 
 const uno = createGenerator({ presets: [presetWarp()] })
-const devClasses = ['!m-16', 'opacity-50']
+const devClasses = ['!m-16', 'i-bg-$foo']
 const cliClasses = process.argv.slice(2)
 const classes = cliClasses.length ? cliClasses : devClasses
 const result = await uno.generate(classes)

--- a/src/_rules/aspect-ratio.js
+++ b/src/_rules/aspect-ratio.js
@@ -1,0 +1,22 @@
+import { escapeSelector, entriesToCss } from '@unocss/core'
+import { handler as h } from '#utils'
+
+const childStyles = entriesToCss(Object.entries({
+  position: 'absolute',
+  height: '100%',
+  width: '100%',
+  top: '0',
+  right: '0',
+  bottom: '0',
+  left: '0',
+}))
+
+export const arBackport = [
+  [/^aspect-(.+)$/, ([_selector, d]) => {
+    const selector = escapeSelector(_selector)
+    const ratioAsPercentage = h.inverseFraction(d)
+    const base = `.${selector}{position:relative;padding-bottom:${ratioAsPercentage};}`
+    const child = `.${selector}>*{${childStyles}}`
+    return base + child
+  }, { autocomplete: ['aspect-(ratio)'] }],
+]

--- a/src/_rules/index.js
+++ b/src/_rules/index.js
@@ -1,4 +1,5 @@
 import * as align from "./align.js";
+import * as aspectRatio from "./aspect-ratio.js";
 import * as backgrounds from './background.js'
 import * as behaviors from "./behaviors.js";
 import * as border from "./border.js";
@@ -9,6 +10,7 @@ import * as flex from "./flex.js";
 import * as focusRing from "./focus-ring.js";
 import * as gap from "./gap.js";
 import * as grid from "./grid.js";
+import * as internal from './internal.js'
 import * as layout from "./layout.js";
 import * as lineClamp from "./line-clamp.js";
 import * as position from "./position.js";
@@ -22,6 +24,7 @@ import * as table from "./table.js";
 
 const ruleGroups = {
   ...align,
+  ...aspectRatio,
   ...backgrounds,
   ...behaviors,
   ...border,
@@ -33,6 +36,7 @@ const ruleGroups = {
   ...focusRing,
   ...gap,
   ...grid,
+  ...internal,
   ...layout,
   ...lineClamp,
   ...position,
@@ -49,6 +53,7 @@ export const rules = [
 ].flat(1);
 
 export * from "./align.js";
+export * from "./aspect-ratio.js";
 export * from './background.js'
 export * from "./behaviors.js";
 export * from "./border.js";
@@ -59,6 +64,7 @@ export * from "./flex.js";
 export * from "./focus-ring.js";
 export * from "./gap.js";
 export * from "./grid.js";
+export * from './internal.js';
 export * from "./layout.js";
 export * from "./line-clamp.js"
 export * from "./position.js";

--- a/src/_rules/internal.js
+++ b/src/_rules/internal.js
@@ -1,0 +1,7 @@
+import { handler as h } from '#utils'
+
+export const internalRules = [
+  [/^i-bg-(.+)$/, ([, cssvar]) => ({ backgroundColor: h.warptoken(cssvar) })],
+  [/^i-text-(.+)$/, ([, cssvar]) => ({ color: h.warptoken(cssvar) })],
+  [/^i-border-(.+)$/, ([, cssvar]) => ({ borderColor: h.warptoken(cssvar) })],
+]

--- a/src/_rules/internal.js
+++ b/src/_rules/internal.js
@@ -1,7 +1,7 @@
 import { handler as h } from '#utils'
 
 export const internalRules = [
-  [/^i-bg-(.+)$/, ([, cssvar]) => ({ backgroundColor: h.warptoken(cssvar) })],
-  [/^i-text-(.+)$/, ([, cssvar]) => ({ color: h.warptoken(cssvar) })],
-  [/^i-border-(.+)$/, ([, cssvar]) => ({ borderColor: h.warptoken(cssvar) })],
+  [/^i-bg-(.+)$/, ([, cssvar]) => ({ backgroundColor: h.warpToken(cssvar) })],
+  [/^i-text-(.+)$/, ([, cssvar]) => ({ color: h.warpToken(cssvar) })],
+  [/^i-border-(.+)$/, ([, cssvar]) => ({ borderColor: h.warpToken(cssvar) })],
 ]

--- a/src/_rules/size.js
+++ b/src/_rules/size.js
@@ -40,15 +40,3 @@ export const sizes = [
     ],
   }],
 ];
-
-function getAspectRatio(prop) {
-  if (/^\d+\/\d+$/.test(prop)) return prop;
-  switch (prop) {
-    case 'square': return '1/1';
-    case 'video': return '16/9';
-  }
-  return h.global.auto.number(prop);
-}
-export const aspectRatio = [
-  [/^aspect-(?:ratio-)?(.+)$/, ([, d]) => ({ 'aspect-ratio': getAspectRatio(d) }), { autocomplete: ['aspect-(square|video|ratio)', 'aspect-ratio-(square|video)'] }],
-];

--- a/src/_utils/handlers/handlers.js
+++ b/src/_utils/handlers/handlers.js
@@ -146,7 +146,7 @@ export function bracketOfLength(str) {
 export function bracketOfPosition(str) {
     return bracketWithType(str, 'position');
 }
-export function warptoken(str) {
+export function warpToken(str) {
     if (str.match(/^\$\S/))
         return `var(--w-${escapeSelector(str.slice(1))})`;
 }

--- a/src/_utils/handlers/handlers.js
+++ b/src/_utils/handlers/handlers.js
@@ -70,6 +70,14 @@ export function percent(str) {
     if (!Number.isNaN(num))
         return `${round(num / 100)}`;
 }
+export function inverseFraction(str) {
+    if (str === 'full')
+        return '100%';
+    const [left, right] = str.split('/');
+    const num = parseFloat(right) / parseFloat(left);
+    if (!Number.isNaN(num))
+        return `${round(num * 100)}%`;
+}
 export function fraction(str) {
     if (str === 'full')
         return '100%';
@@ -137,6 +145,10 @@ export function bracketOfLength(str) {
 }
 export function bracketOfPosition(str) {
     return bracketWithType(str, 'position');
+}
+export function warptoken(str) {
+    if (str.match(/^\$\S/))
+        return `var(--w-${escapeSelector(str.slice(1))})`;
 }
 export function cssvar(str) {
     if (str.match(/^\$\S/))

--- a/test/__snapshots__/aspect-ratio.js.snap
+++ b/test/__snapshots__/aspect-ratio.js.snap
@@ -1,0 +1,9 @@
+// Vitest Snapshot v1
+
+exports[`it generates backported aspect-ratios 1`] = `
+"/* layer: default */
+.aspect-1\\\\/1{position:relative;padding-bottom:100%;}.aspect-1\\\\/1>*{position:absolute;height:100%;width:100%;top:0;right:0;bottom:0;left:0;}
+.aspect-16\\\\/9{position:relative;padding-bottom:56.25%;}.aspect-16\\\\/9>*{position:absolute;height:100%;width:100%;top:0;right:0;bottom:0;left:0;}
+.aspect-2\\\\/1{position:relative;padding-bottom:50%;}.aspect-2\\\\/1>*{position:absolute;height:100%;width:100%;top:0;right:0;bottom:0;left:0;}
+.aspect-4\\\\/3{position:relative;padding-bottom:75%;}.aspect-4\\\\/3>*{position:absolute;height:100%;width:100%;top:0;right:0;bottom:0;left:0;}"
+`;

--- a/test/__snapshots__/internal.js.snap
+++ b/test/__snapshots__/internal.js.snap
@@ -1,0 +1,8 @@
+// Vitest Snapshot v1
+
+exports[`it generates css based on warp tokens 1`] = `
+"/* layer: default */
+.i-bg-\\\\$foo-bar{backgroundColor:var(--w-foo-bar);}
+.i-text-\\\\$biz-baz{color:var(--w-biz-baz);}
+.i-border-\\\\$wombat-llama{borderColor:var(--w-wombat-llama);}"
+`;

--- a/test/aspect-ratio.js
+++ b/test/aspect-ratio.js
@@ -1,0 +1,10 @@
+import { setup } from './_helpers.js'
+import { expect, test } from 'vitest'
+
+setup()
+
+test('it generates backported aspect-ratios', async ({ uno }) => {
+  const classes = ['aspect-16/9', 'aspect-1/1', 'aspect-4/3', 'aspect-2/1']
+  const { css } = await uno.generate(classes)
+  expect(css).toMatchSnapshot()
+})

--- a/test/internal.js
+++ b/test/internal.js
@@ -1,0 +1,11 @@
+import { setup } from './_helpers.js'
+import { expect, test } from 'vitest'
+
+setup()
+
+test('it generates css based on warp tokens', async ({ uno }) => {
+  const classes = ['i-bg-$foo-bar', 'i-text-$biz-baz', 'i-border-$wombat-llama']
+  const anticlasses = ['i-bg-foos-bars', 'i-text-bizs-bazs', 'i-border-wombats-llamas', 'i-magnuseses']
+  const { css } = await uno.generate([...classes, ...anticlasses])
+  expect(css).toMatchSnapshot()
+})


### PR DESCRIPTION
- Add aspect ratio in a more ergonomic and TW-ish way: e.g. `aspect-16/9` instead of `aspect-w-16 aspect-h-9`
- Drop support for `aspect-none`, only one team was using it - the same effect should be doable using our improved support for breakpoints - e.g. `lt-sm:aspect-16/9` instead of `aspect-16/9 sm:aspect-none`
- Set up first internal classes, not sure if it might be better to include what they target, but we can fix that later - e.g. we might want `i-text-c-$foo` so we know it targets color instead of just `i-text-$foo`. Because we're only reading straight from a CSSvar with all these rules we can't really make 'smart' rules that change behavior based on some pattern.