### PR TITLE
Wire up externalization of 'core' classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,27 @@
-# checking fabric classes
+# drive - an UnoCSS preset
+
+## use
+
+## plugin API
+
+### usePreflight
+
+- `boolean`
+- Forces preflights to be included
+
+### development
+
+- `boolean`
+- Will include preflights and base classes when true. These would be 'externalized' to Eik in production builds.
+
+### usePixels
+
+- `boolean`
+- Internal use only, for use on sites that are incompatible with root REM/`font-size` changes
+
+## migration development
+
+## checking fabric classes
 
 1. Check out the `parity` project from warp-ds, get dependencies for the project
 2. Link to the `parity` project from the `plugin` folder (this folder): `pnpm link ../parity`

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "#theme": "./src/theme.js",
     "#variants": "./src/_variants/index.js",
     "#preflights": "./src/_preflights/index.js",
+    "#postprocess": "./src/postprocessor.js",
     "#bounding": "./src/bounding.js",
     "#bounds": "./src/bounds.js"
   },

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -17,7 +17,8 @@ import { postprocess } from '#postprocess';
 /** @type {import('@unocss/core').Preset<object>} */
 export function presetWarp (options = {}) {
   const hasPreflight = options.usePreflight ?? options.development
-  const externalizeCore = options.includeCoreClasses ?? !options.development
+  const externalizeClasses = options.externalizeClasses ?? !options.development
+  const externalClasses = options.externalClasses ?? [] // will possibly be our own list in the future
   const theme = useTheme(options);
   return {
     name: '@warp-ds/uno',
@@ -25,7 +26,7 @@ export function presetWarp (options = {}) {
     rules,
     variants,
     preflights: hasPreflight ? preflights : [],
-    postprocess: postprocess(externalizeCore)
+    postprocess: postprocess(externalizeClasses, externalClasses)
   };
 }
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -8,8 +8,8 @@ import { postprocess } from '#postprocess';
  * @typedef PluginOptions
  * @type {Object}
  * @property {boolean} development // not in use yet
- * @property {boolean} usePreflight - force preflights to be included
- * @property {boolean} includeCoreClasses - force core classes to be included
+ * @property {boolean} usePreflight - force preflights to be included/excluded
+ * @property {boolean} externalizeClasses - force external or 'core' classes to be included/excluded
  * @property {boolean} usePixels - use pixel spacing instead of rem
  */
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -2,22 +2,22 @@ import { preflights } from '#preflights';
 import { rules } from '#rules';
 import { variants } from '#variants';
 import { useTheme } from '#theme';
-
-const includePreflight = ['base', 'hyper'];
+import { postprocess } from '#postprocess';
 
 /**
  * @typedef PluginOptions
  * @type {Object}
- * @property {string} mode - one of X, Y, Z - modifies CSS output
  * @property {boolean} development // not in use yet
+ * @property {boolean} usePreflight - force preflights to be included
+ * @property {boolean} includeCoreClasses - force core classes to be included
  * @property {boolean} usePixels - use pixel spacing instead of rem
  */
 
 // TODO: improve generic type passed here
 /** @type {import('@unocss/core').Preset<object>} */
 export function presetWarp (options = {}) {
-  const mode = options.mode ?? 'app';
-  const hasPreflight = options.usePreflight ?? includePreflight.includes(mode);
+  const hasPreflight = options.usePreflight ?? options.development
+  const externalizeCore = options.includeCoreClasses ?? !options.development
   const theme = useTheme(options);
   return {
     name: '@warp-ds/uno',
@@ -25,6 +25,7 @@ export function presetWarp (options = {}) {
     rules,
     variants,
     preflights: hasPreflight ? preflights : [],
+    postprocess: postprocess(externalizeCore)
   };
 }
 

--- a/src/postprocessor.js
+++ b/src/postprocessor.js
@@ -2,13 +2,14 @@ import { escapeSelector } from '@unocss/core'
 
 const prefix = 'w-'
 const classify = (str) => `.${escapeSelector(str)}`
-const coreClasses = [].map(classify) // temporary fixture
 
-export const postprocess = (externalizeCore) => (obj) => {
-  if (externalizeCore && coreClasses.includes(obj.selector)) return obj.entries = null
-  obj.entries.forEach(e => {
-    e[0] = e[0].replace(/^--un-/, `--${prefix}`);
-    if (typeof e[1] === "string") e[1] = e[1].replace(/var\(--un-/g, `var(--${prefix}`);
-  })
+export const postprocess = (externalizeCore, _externalClasses = []) => {
+  const externalClasses = _externalClasses.map(classify)
+  return (obj) => {
+    if (externalizeCore && externalClasses.includes(obj.selector)) return obj.entries = null
+    obj.entries.forEach(e => {
+      e[0] = e[0].replace(/^--un-/, `--${prefix}`);
+      if (typeof e[1] === "string") e[1] = e[1].replace(/var\(--un-/g, `var(--${prefix}`);
+    })
+  }
 }
-

--- a/src/postprocessor.js
+++ b/src/postprocessor.js
@@ -3,10 +3,10 @@ import { escapeSelector } from '@unocss/core'
 const prefix = 'w-'
 const classify = (str) => `.${escapeSelector(str)}`
 
-export const postprocess = (externalizeCore, _externalClasses = []) => {
+export const postprocess = (shouldExternalize, _externalClasses = []) => {
   const externalClasses = _externalClasses.map(classify)
   return (obj) => {
-    if (externalizeCore && externalClasses.includes(obj.selector)) return obj.entries = null
+    if (shouldExternalize && externalClasses.includes(obj.selector)) return obj.entries = null
     obj.entries.forEach(e => {
       e[0] = e[0].replace(/^--un-/, `--${prefix}`);
       if (typeof e[1] === "string") e[1] = e[1].replace(/var\(--un-/g, `var(--${prefix}`);

--- a/src/postprocessor.js
+++ b/src/postprocessor.js
@@ -1,0 +1,14 @@
+import { escapeSelector } from '@unocss/core'
+
+const prefix = 'w-'
+const classify = (str) => `.${escapeSelector(str)}`
+const coreClasses = [].map(classify) // temporary fixture
+
+export const postprocess = (externalizeCore) => (obj) => {
+  if (externalizeCore && coreClasses.includes(obj.selector)) return obj.entries = null
+  obj.entries.forEach(e => {
+    e[0] = e[0].replace(/^--un-/, `--${prefix}`);
+    if (typeof e[1] === "string") e[1] = e[1].replace(/var\(--un-/g, `var(--${prefix}`);
+  })
+}
+

--- a/test/general.js
+++ b/test/general.js
@@ -40,3 +40,13 @@ test('can generate pixel values for theme', async () => {
     .-ml-32{margin-left:-32px;}"
   `);
 });
+
+test('it can externalize classes', async () => {
+  const uno = getGenerator({ externalizeClasses: true, externalClasses: ['p-16', '-ml-32'] });
+  const { css } = await uno.generate(['pt-8', 'bottom-4', '-ml-32']);
+  expect(css).toMatchInlineSnapshot(`
+    "/* layer: default */
+    .bottom-4{bottom:0.4rem;}
+    .pt-8{padding-top:0.8rem;}"
+  `)
+})


### PR DESCRIPTION
This creates support for an array of classes (like our component classes) to be passed to the plugin and then blacklisted from the resulting CSS.