### PR TITLE
Feat/add rules for arbitrary values for (max/min-)width/height

### DIFF
--- a/src/_rules/size.js
+++ b/src/_rules/size.js
@@ -39,5 +39,5 @@ export const sizes = [
       '(min|max)-w-screen-$breakpoints',
     ],
   }],
-  [/^(min-|max-)?([wh])-\[(\d+)]$/, ([, minmax, wOrH, d]) => ({ [getPropName(minmax, wOrH)]: h.rem(d) })],
+  [/^(min-|max-)?([wh])-\[(\d+)]$/, ([, minmax, wOrH, d], context) => ({ [getPropName(minmax, wOrH)]: context.theme.usingPixels ? h.px(d) : h.rem(d) })],
 ];

--- a/src/_rules/size.js
+++ b/src/_rules/size.js
@@ -2,6 +2,11 @@ import { handler as h, resolveBreakpoints, resolveVerticalBreakpoints } from '#u
 
 const sizeMapping = { h: 'height', w: 'width' };
 const getPropName = (minmax, hw) => `${minmax || ''}${sizeMapping[hw]}`;
+const resolveArbitraryValues = (d, unit, context) => {
+  if (unit === "rem") return h.rem(`${d}${unit}`);
+  if (unit === "px" || context.theme.usingPixels) return h.px(d);
+  return h.rem(d);
+};
 
 function getSizeValue(minmax, hw, theme, prop) {
   const str = getPropName(minmax, hw).replace(/-(\w)/g, (_, p) => p.toUpperCase());
@@ -39,5 +44,5 @@ export const sizes = [
       '(min|max)-w-screen-$breakpoints',
     ],
   }],
-  [/^(min-|max-)?([wh])-\[(\d+)]$/, ([, minmax, wOrH, d], context) => ({ [getPropName(minmax, wOrH)]: context.theme.usingPixels ? h.px(d) : h.rem(d) })],
+  [/^(min-|max-)?([wh])-\[(\d+)(rem|px)?]$/, ([, minmax, wh, d, unit], context) => ({ [getPropName(minmax, wh)]:  resolveArbitraryValues(d, unit, context) })],
 ];

--- a/src/_rules/size.js
+++ b/src/_rules/size.js
@@ -39,5 +39,5 @@ export const sizes = [
       '(min|max)-w-screen-$breakpoints',
     ],
   }],
-  [/^(min-|max-)?([wh])-\[(\d+)]$/, ([, minmax, wOrH, d]) => ({ [getPropName(minmax, wOrH)]: `${h.number(d) / 10}rem` })],
+  [/^(min-|max-)?([wh])-\[(\d+)]$/, ([, minmax, wOrH, d]) => ({ [getPropName(minmax, wOrH)]: h.rem(d) })],
 ];

--- a/src/_rules/size.js
+++ b/src/_rules/size.js
@@ -39,4 +39,5 @@ export const sizes = [
       '(min|max)-w-screen-$breakpoints',
     ],
   }],
+  [/^(min-|max-)?([wh])-\[(\d+)]$/, ([, minmax, wOrH, d]) => ({ [getPropName(minmax, wOrH)]: `${h.number(d) / 10}rem` })],
 ];

--- a/src/theme.js
+++ b/src/theme.js
@@ -58,7 +58,7 @@ export const useTheme = (opts = {}) => {
   const height = { ...baseSpacing, screen: '100vh' };
 
   return {
-    usingPixels: !!opts.pxSpacing,
+    usingPixels: !!opts.usePixels,
     breakpoints,
     borderRadius,
     verticalBreakpoints: breakpoints,

--- a/test/__snapshots__/size.js.snap
+++ b/test/__snapshots__/size.js.snap
@@ -110,6 +110,20 @@ exports[`max width and height > max-width 1`] = `
 .max-w-screen{max-width:100vw;}"
 `;
 
+exports[`max width and height with arbitrary values > max-height 1`] = `
+"/* layer: default */
+.max-h-\\\\[20000\\\\]{max-height:2000rem;}
+.max-h-\\\\[378\\\\]{max-height:37.8rem;}
+.max-h-\\\\[99999\\\\]{max-height:9999.9rem;}"
+`;
+
+exports[`max width and height with arbitrary values > max-width 1`] = `
+"/* layer: default */
+.max-w-\\\\[20000\\\\]{max-width:2000rem;}
+.max-w-\\\\[378\\\\]{max-width:37.8rem;}
+.max-w-\\\\[99999\\\\]{max-width:9999.9rem;}"
+`;
+
 exports[`min width and height > min-height 1`] = `
 "/* layer: default */
 .min-h-0{min-height:0rem;}
@@ -218,6 +232,27 @@ exports[`min width and height > min-width 1`] = `
 .min-w-screen{min-width:100vw;}"
 `;
 
+exports[`min width and height with arbitrary values > min-height 1`] = `
+"/* layer: default */
+.min-h-\\\\[20000\\\\]{min-height:2000rem;}
+.min-h-\\\\[378\\\\]{min-height:37.8rem;}
+.min-h-\\\\[99999\\\\]{min-height:9999.9rem;}"
+`;
+
+exports[`min width and height with arbitrary values > min-width 1`] = `
+"/* layer: default */
+.min-w-\\\\[20000\\\\]{min-width:2000rem;}
+.min-w-\\\\[378\\\\]{min-width:37.8rem;}
+.min-w-\\\\[99999\\\\]{min-width:9999.9rem;}"
+`;
+
+exports[`min width and height with arbitrary values > min-width 2`] = `
+"/* layer: default */
+.min-w-\\\\[20000\\\\]{min-width:2000rem;}
+.min-w-\\\\[378\\\\]{min-width:37.8rem;}
+.min-w-\\\\[99999\\\\]{min-width:9999.9rem;}"
+`;
+
 exports[`width and height > height 1`] = `
 "/* layer: default */
 .h-0{height:0rem;}
@@ -324,4 +359,18 @@ exports[`width and height > width 1`] = `
 .w-max{width:max-content;}
 .w-min{width:min-content;}
 .w-screen{width:100vw;}"
+`;
+
+exports[`width and height with arbitrary values > height 1`] = `
+"/* layer: default */
+.h-\\\\[20000\\\\]{height:2000rem;}
+.h-\\\\[378\\\\]{height:37.8rem;}
+.h-\\\\[99999\\\\]{height:9999.9rem;}"
+`;
+
+exports[`width and height with arbitrary values > width 1`] = `
+"/* layer: default */
+.w-\\\\[20000\\\\]{width:2000rem;}
+.w-\\\\[378\\\\]{width:37.8rem;}
+.w-\\\\[99999\\\\]{width:9999.9rem;}"
 `;

--- a/test/__snapshots__/size.js.snap
+++ b/test/__snapshots__/size.js.snap
@@ -110,11 +110,25 @@ exports[`max width and height > max-width 1`] = `
 .max-w-screen{max-width:100vw;}"
 `;
 
+exports[`max width and height with arbitrary values > max-height with pixel unit 1`] = `
+"/* layer: default */
+.max-h-\\\\[20000px\\\\]{max-height:20000px;}
+.max-h-\\\\[378px\\\\]{max-height:378px;}
+.max-h-\\\\[99999px\\\\]{max-height:99999px;}"
+`;
+
 exports[`max width and height with arbitrary values > max-height with pixel values 1`] = `
 "/* layer: default */
 .max-h-\\\\[20000\\\\]{max-height:20000px;}
 .max-h-\\\\[378\\\\]{max-height:378px;}
 .max-h-\\\\[99999\\\\]{max-height:99999px;}"
+`;
+
+exports[`max width and height with arbitrary values > max-height with rem unit 1`] = `
+"/* layer: default */
+.max-h-\\\\[20000rem\\\\]{max-height:20000rem;}
+.max-h-\\\\[378rem\\\\]{max-height:378rem;}
+.max-h-\\\\[99999rem\\\\]{max-height:99999rem;}"
 `;
 
 exports[`max width and height with arbitrary values > max-height with rem values 1`] = `
@@ -124,11 +138,25 @@ exports[`max width and height with arbitrary values > max-height with rem values
 .max-h-\\\\[99999\\\\]{max-height:9999.9rem;}"
 `;
 
+exports[`max width and height with arbitrary values > max-width with pixel unit 1`] = `
+"/* layer: default */
+.max-w-\\\\[20000px\\\\]{max-width:20000px;}
+.max-w-\\\\[378px\\\\]{max-width:378px;}
+.max-w-\\\\[99999px\\\\]{max-width:99999px;}"
+`;
+
 exports[`max width and height with arbitrary values > max-width with pixel values 1`] = `
 "/* layer: default */
 .max-w-\\\\[20000\\\\]{max-width:20000px;}
 .max-w-\\\\[378\\\\]{max-width:378px;}
 .max-w-\\\\[99999\\\\]{max-width:99999px;}"
+`;
+
+exports[`max width and height with arbitrary values > max-width with rem unit 1`] = `
+"/* layer: default */
+.max-w-\\\\[20000rem\\\\]{max-width:20000rem;}
+.max-w-\\\\[378rem\\\\]{max-width:378rem;}
+.max-w-\\\\[99999rem\\\\]{max-width:99999rem;}"
 `;
 
 exports[`max width and height with arbitrary values > max-width with rem values 1`] = `
@@ -246,11 +274,25 @@ exports[`min width and height > min-width 1`] = `
 .min-w-screen{min-width:100vw;}"
 `;
 
+exports[`min width and height with arbitrary values > min-height with pixel unit 1`] = `
+"/* layer: default */
+.min-h-\\\\[20000px\\\\]{min-height:20000px;}
+.min-h-\\\\[378px\\\\]{min-height:378px;}
+.min-h-\\\\[99999px\\\\]{min-height:99999px;}"
+`;
+
 exports[`min width and height with arbitrary values > min-height with pixel values 1`] = `
 "/* layer: default */
 .min-h-\\\\[20000\\\\]{min-height:20000px;}
 .min-h-\\\\[378\\\\]{min-height:378px;}
 .min-h-\\\\[99999\\\\]{min-height:99999px;}"
+`;
+
+exports[`min width and height with arbitrary values > min-height with rem unit 1`] = `
+"/* layer: default */
+.min-h-\\\\[20000rem\\\\]{min-height:20000rem;}
+.min-h-\\\\[378rem\\\\]{min-height:378rem;}
+.min-h-\\\\[99999rem\\\\]{min-height:99999rem;}"
 `;
 
 exports[`min width and height with arbitrary values > min-height with rem values 1`] = `
@@ -260,11 +302,25 @@ exports[`min width and height with arbitrary values > min-height with rem values
 .min-h-\\\\[99999\\\\]{min-height:9999.9rem;}"
 `;
 
+exports[`min width and height with arbitrary values > min-width with pixel unit 1`] = `
+"/* layer: default */
+.min-w-\\\\[20000px\\\\]{min-width:20000px;}
+.min-w-\\\\[378px\\\\]{min-width:378px;}
+.min-w-\\\\[99999px\\\\]{min-width:99999px;}"
+`;
+
 exports[`min width and height with arbitrary values > min-width with pixel values 1`] = `
 "/* layer: default */
 .min-w-\\\\[20000\\\\]{min-width:20000px;}
 .min-w-\\\\[378\\\\]{min-width:378px;}
 .min-w-\\\\[99999\\\\]{min-width:99999px;}"
+`;
+
+exports[`min width and height with arbitrary values > min-width with rem unit 1`] = `
+"/* layer: default */
+.min-w-\\\\[20000rem\\\\]{min-width:20000rem;}
+.min-w-\\\\[378rem\\\\]{min-width:378rem;}
+.min-w-\\\\[99999rem\\\\]{min-width:99999rem;}"
 `;
 
 exports[`min width and height with arbitrary values > min-width with rem values 1`] = `
@@ -382,11 +438,25 @@ exports[`width and height > width 1`] = `
 .w-screen{width:100vw;}"
 `;
 
+exports[`width and height with arbitrary values > height with pixel unit 1`] = `
+"/* layer: default */
+.h-\\\\[20000px\\\\]{height:20000px;}
+.h-\\\\[378px\\\\]{height:378px;}
+.h-\\\\[99999px\\\\]{height:99999px;}"
+`;
+
 exports[`width and height with arbitrary values > height with pixel values 1`] = `
 "/* layer: default */
 .h-\\\\[20000\\\\]{height:20000px;}
 .h-\\\\[378\\\\]{height:378px;}
 .h-\\\\[99999\\\\]{height:99999px;}"
+`;
+
+exports[`width and height with arbitrary values > height with rem unit 1`] = `
+"/* layer: default */
+.h-\\\\[20000rem\\\\]{height:20000rem;}
+.h-\\\\[378rem\\\\]{height:378rem;}
+.h-\\\\[99999rem\\\\]{height:99999rem;}"
 `;
 
 exports[`width and height with arbitrary values > height with rem values 1`] = `
@@ -396,11 +466,25 @@ exports[`width and height with arbitrary values > height with rem values 1`] = `
 .h-\\\\[99999\\\\]{height:9999.9rem;}"
 `;
 
+exports[`width and height with arbitrary values > width with pixel unit 1`] = `
+"/* layer: default */
+.w-\\\\[20000px\\\\]{width:20000px;}
+.w-\\\\[378px\\\\]{width:378px;}
+.w-\\\\[99999px\\\\]{width:99999px;}"
+`;
+
 exports[`width and height with arbitrary values > width with pixel values 1`] = `
 "/* layer: default */
 .w-\\\\[20000\\\\]{width:20000px;}
 .w-\\\\[378\\\\]{width:378px;}
 .w-\\\\[99999\\\\]{width:99999px;}"
+`;
+
+exports[`width and height with arbitrary values > width with rem unit 1`] = `
+"/* layer: default */
+.w-\\\\[20000rem\\\\]{width:20000rem;}
+.w-\\\\[378rem\\\\]{width:378rem;}
+.w-\\\\[99999rem\\\\]{width:99999rem;}"
 `;
 
 exports[`width and height with arbitrary values > width with rem values 1`] = `

--- a/test/__snapshots__/size.js.snap
+++ b/test/__snapshots__/size.js.snap
@@ -110,14 +110,28 @@ exports[`max width and height > max-width 1`] = `
 .max-w-screen{max-width:100vw;}"
 `;
 
-exports[`max width and height with arbitrary values > max-height 1`] = `
+exports[`max width and height with arbitrary values > max-height with pixel values 1`] = `
+"/* layer: default */
+.max-h-\\\\[20000\\\\]{max-height:20000px;}
+.max-h-\\\\[378\\\\]{max-height:378px;}
+.max-h-\\\\[99999\\\\]{max-height:99999px;}"
+`;
+
+exports[`max width and height with arbitrary values > max-height with rem values 1`] = `
 "/* layer: default */
 .max-h-\\\\[20000\\\\]{max-height:2000rem;}
 .max-h-\\\\[378\\\\]{max-height:37.8rem;}
 .max-h-\\\\[99999\\\\]{max-height:9999.9rem;}"
 `;
 
-exports[`max width and height with arbitrary values > max-width 1`] = `
+exports[`max width and height with arbitrary values > max-width with pixel values 1`] = `
+"/* layer: default */
+.max-w-\\\\[20000\\\\]{max-width:20000px;}
+.max-w-\\\\[378\\\\]{max-width:378px;}
+.max-w-\\\\[99999\\\\]{max-width:99999px;}"
+`;
+
+exports[`max width and height with arbitrary values > max-width with rem values 1`] = `
 "/* layer: default */
 .max-w-\\\\[20000\\\\]{max-width:2000rem;}
 .max-w-\\\\[378\\\\]{max-width:37.8rem;}
@@ -232,21 +246,28 @@ exports[`min width and height > min-width 1`] = `
 .min-w-screen{min-width:100vw;}"
 `;
 
-exports[`min width and height with arbitrary values > min-height 1`] = `
+exports[`min width and height with arbitrary values > min-height with pixel values 1`] = `
+"/* layer: default */
+.min-h-\\\\[20000\\\\]{min-height:20000px;}
+.min-h-\\\\[378\\\\]{min-height:378px;}
+.min-h-\\\\[99999\\\\]{min-height:99999px;}"
+`;
+
+exports[`min width and height with arbitrary values > min-height with rem values 1`] = `
 "/* layer: default */
 .min-h-\\\\[20000\\\\]{min-height:2000rem;}
 .min-h-\\\\[378\\\\]{min-height:37.8rem;}
 .min-h-\\\\[99999\\\\]{min-height:9999.9rem;}"
 `;
 
-exports[`min width and height with arbitrary values > min-width 1`] = `
+exports[`min width and height with arbitrary values > min-width with pixel values 1`] = `
 "/* layer: default */
-.min-w-\\\\[20000\\\\]{min-width:2000rem;}
-.min-w-\\\\[378\\\\]{min-width:37.8rem;}
-.min-w-\\\\[99999\\\\]{min-width:9999.9rem;}"
+.min-w-\\\\[20000\\\\]{min-width:20000px;}
+.min-w-\\\\[378\\\\]{min-width:378px;}
+.min-w-\\\\[99999\\\\]{min-width:99999px;}"
 `;
 
-exports[`min width and height with arbitrary values > min-width 2`] = `
+exports[`min width and height with arbitrary values > min-width with rem values 1`] = `
 "/* layer: default */
 .min-w-\\\\[20000\\\\]{min-width:2000rem;}
 .min-w-\\\\[378\\\\]{min-width:37.8rem;}
@@ -361,14 +382,28 @@ exports[`width and height > width 1`] = `
 .w-screen{width:100vw;}"
 `;
 
-exports[`width and height with arbitrary values > height 1`] = `
+exports[`width and height with arbitrary values > height with pixel values 1`] = `
+"/* layer: default */
+.h-\\\\[20000\\\\]{height:20000px;}
+.h-\\\\[378\\\\]{height:378px;}
+.h-\\\\[99999\\\\]{height:99999px;}"
+`;
+
+exports[`width and height with arbitrary values > height with rem values 1`] = `
 "/* layer: default */
 .h-\\\\[20000\\\\]{height:2000rem;}
 .h-\\\\[378\\\\]{height:37.8rem;}
 .h-\\\\[99999\\\\]{height:9999.9rem;}"
 `;
 
-exports[`width and height with arbitrary values > width 1`] = `
+exports[`width and height with arbitrary values > width with pixel values 1`] = `
+"/* layer: default */
+.w-\\\\[20000\\\\]{width:20000px;}
+.w-\\\\[378\\\\]{width:378px;}
+.w-\\\\[99999\\\\]{width:99999px;}"
+`;
+
+exports[`width and height with arbitrary values > width with rem values 1`] = `
 "/* layer: default */
 .w-\\\\[20000\\\\]{width:2000rem;}
 .w-\\\\[378\\\\]{width:37.8rem;}

--- a/test/size.js
+++ b/test/size.js
@@ -58,3 +58,124 @@ describe('min width and height', () => {
     expect(css).toMatchSnapshot();
   });
 });
+
+
+describe("width and height with arbitrary values", () => {
+  test('width', async (t) => {
+    const classes = ['w-[20000]', 'w-[99999]', 'w-[378]'];
+
+    const { css } = await t.uno.generate(classes);
+    expect(css).toMatchSnapshot();
+  });
+  test('width', async (t) => {
+    const classes = ['w-[20000a]', 'w-[99999rem]', 'w-[378px]'];
+
+    const { css } = await t.uno.generate(classes);
+    expect(css).toMatchInlineSnapshot('""');
+  });
+  test('width with invalid non-arbitrary value', async (t) => {
+    const classes = ['w-20000', 'w-99999', 'w-378'];
+
+    const { css } = await t.uno.generate(classes);
+    expect(css).toMatchInlineSnapshot('""');
+  });
+  test('height', async (t) => {
+    const classes = ['h-[20000]', 'h-[99999]', 'h-[378]'];
+
+    const { css } = await t.uno.generate(classes);
+    expect(css).toMatchSnapshot();
+  });
+  test('height with invalid arbitrary value', async (t) => {
+    const classes = ['h-[20000a]', 'h-[99999rem]', 'h-[378px]'];
+
+    const { css } = await t.uno.generate(classes);
+    expect(css).toMatchInlineSnapshot('""');
+  });
+
+  test('height with invalid non-arbitrary value', async (t) => {
+    const classes = ['h-20000', 'h-99999', 'h-378'];
+
+    const { css } = await t.uno.generate(classes);
+    expect(css).toMatchInlineSnapshot('""');
+  });
+});
+
+describe("min width and height with arbitrary values", () => {
+  test('min-width', async (t) => {
+    const classes = ['min-w-[20000]', 'min-w-[99999]', 'min-w-[378]'];
+
+    const { css } = await t.uno.generate(classes);
+    expect(css).toMatchSnapshot();
+  });
+  test('min-width', async (t) => {
+    const classes = ['min-w-[20000a]', 'min-w-[99999rem]', 'min-w-[378px]'];
+
+    const { css } = await t.uno.generate(classes);
+    expect(css).toMatchInlineSnapshot('""');
+  });
+  test('min-width with invalid non-arbitrary value', async (t) => {
+    const classes = ['min-w-20000', 'min-w-99999', 'min-w-378'];
+
+    const { css } = await t.uno.generate(classes);
+    expect(css).toMatchInlineSnapshot('""');
+  });
+  test('min-height', async (t) => {
+    const classes = ['min-h-[20000]', 'min-h-[99999]', 'min-h-[378]'];
+
+    const { css } = await t.uno.generate(classes);
+    expect(css).toMatchSnapshot();
+  });
+  test('min-height with invalid arbitrary value', async (t) => {
+    const classes = ['min-h-[20000a]', 'min-h-[99999rem]', 'min-h-[378px]'];
+
+    const { css } = await t.uno.generate(classes);
+    expect(css).toMatchInlineSnapshot('""');
+  });
+
+  test('min-height with invalid non-arbitrary value', async (t) => {
+    const classes = ['min-h-20000', 'min-h-99999', 'min-h-378'];
+
+    const { css } = await t.uno.generate(classes);
+    expect(css).toMatchInlineSnapshot('""');
+  });
+});
+
+describe("max width and height with arbitrary values", () => {
+  test('max-width', async (t) => {
+    const classes = ['max-w-[20000]', 'max-w-[99999]', 'max-w-[378]'];
+
+    const { css } = await t.uno.generate(classes);
+    expect(css).toMatchSnapshot();
+  });
+  test('max-width', async (t) => {
+    const classes = ['max-w-[20000a]', 'max-w-[99999rem]', 'max-w-[378px]'];
+
+    const { css } = await t.uno.generate(classes);
+    expect(css).toMatchInlineSnapshot('""');
+  });
+  test('max-width with invalid non-arbitrary value', async (t) => {
+    const classes = ['max-w-20000', 'max-w-99999', 'max-w-378'];
+
+    const { css } = await t.uno.generate(classes);
+    expect(css).toMatchInlineSnapshot('""');
+  });
+  test('max-height', async (t) => {
+    const classes = ['max-h-[20000]', 'max-h-[99999]', 'max-h-[378]'];
+
+    const { css } = await t.uno.generate(classes);
+    expect(css).toMatchSnapshot();
+  });
+  test('max-height with invalid arbitrary value', async (t) => {
+    const classes = ['max-h-[20000a]', 'max-h-[99999rem]', 'max-h-[378px]'];
+
+    const { css } = await t.uno.generate(classes);
+    expect(css).toMatchInlineSnapshot('""');
+  });
+
+  test('max-height with invalid non-arbitrary value', async (t) => {
+    const classes = ['max-h-20000', 'max-h-99999', 'max-h-378'];
+
+    const { css } = await t.uno.generate(classes);
+    expect(css).toMatchInlineSnapshot('""');
+  });
+});

--- a/test/size.js
+++ b/test/size.js
@@ -67,6 +67,12 @@ describe("width and height with arbitrary values", () => {
     const { css } = await t.uno.generate(classes);
     expect(css).toMatchSnapshot();
   });
+  test('width with rem unit', async (t) => {
+    const classes = ['w-[20000rem]', 'w-[99999rem]', 'w-[378rem]'];
+
+    const { css } = await t.uno.generate(classes);
+    expect(css).toMatchSnapshot();
+  });
   test('width with pixel values', async () => {
     const classes = ['w-[20000]', 'w-[99999]', 'w-[378]'];
 
@@ -74,8 +80,14 @@ describe("width and height with arbitrary values", () => {
     const { css } = await uno.generate(classes);
     expect(css).toMatchSnapshot();
   });
+  test('width with pixel unit', async (t) => {
+    const classes = ['w-[20000px]', 'w-[99999px]', 'w-[378px]'];
+
+    const { css } = await t.uno.generate(classes);
+    expect(css).toMatchSnapshot();
+  });
   test('width with invalid value', async (t) => {
-    const classes = ['w-20000', 'w-99999', 'w-378', 'w-[20000a]', 'w-[99999rem]', 'w-[378px]'];
+    const classes = ['w-20000', 'w-99999', 'w-378', 'w-[20000a]'];
 
     const { css } = await t.uno.generate(classes);
     expect(css).toMatchInlineSnapshot('""');
@@ -87,6 +99,12 @@ describe("width and height with arbitrary values", () => {
     const { css } = await t.uno.generate(classes);
     expect(css).toMatchSnapshot();
   });
+  test('height with rem unit', async (t) => {
+    const classes = ['h-[20000rem]', 'h-[99999rem]', 'h-[378rem]'];
+
+    const { css } = await t.uno.generate(classes);
+    expect(css).toMatchSnapshot();
+  });
   test('height with pixel values', async () => {
     const classes = ['h-[20000]', 'h-[99999]', 'h-[378]'];
 
@@ -94,8 +112,14 @@ describe("width and height with arbitrary values", () => {
     const { css } = await uno.generate(classes);
     expect(css).toMatchSnapshot();
   });
+  test('height with pixel unit', async (t) => {
+    const classes = ['h-[20000px]', 'h-[99999px]', 'h-[378px]'];
+
+    const { css } = await t.uno.generate(classes);
+    expect(css).toMatchSnapshot();
+  });
   test('height with invalid value', async (t) => {
-    const classes = ['h-20000', 'h-99999', 'h-378', 'h-[20000a]', 'h-[99999rem]', 'h-[378px]'];
+    const classes = ['h-20000', 'h-99999', 'h-378', 'h-[20000a]'];
 
     const { css } = await t.uno.generate(classes);
     expect(css).toMatchInlineSnapshot('""');
@@ -109,6 +133,12 @@ describe("min width and height with arbitrary values", () => {
     const { css } = await t.uno.generate(classes);
     expect(css).toMatchSnapshot();
   });
+  test('min-width with rem unit', async (t) => {
+    const classes = ['min-w-[20000rem]', 'min-w-[99999rem]', 'min-w-[378rem]'];
+
+    const { css } = await t.uno.generate(classes);
+    expect(css).toMatchSnapshot();
+  });
   test('min-width with pixel values', async () => {
     const classes = ['min-w-[20000]', 'min-w-[99999]', 'min-w-[378]'];
 
@@ -116,8 +146,14 @@ describe("min width and height with arbitrary values", () => {
     const { css } = await uno.generate(classes);
     expect(css).toMatchSnapshot();
   });
+  test('min-width with pixel unit', async (t) => {
+    const classes = ['min-w-[20000px]', 'min-w-[99999px]', 'min-w-[378px]'];
+
+    const { css } = await t.uno.generate(classes);
+    expect(css).toMatchSnapshot();
+  });
   test('min-width with invalid value', async (t) => {
-    const classes = ['min-w-20000', 'min-w-99999', 'min-w-378', 'min-w-[20000a]', 'min-w-[99999rem]', 'min-w-[378px]'];
+    const classes = ['min-w-20000', 'min-w-99999', 'min-w-378', 'min-w-[20000a]'];
 
     const { css } = await t.uno.generate(classes);
     expect(css).toMatchInlineSnapshot('""');
@@ -129,6 +165,12 @@ describe("min width and height with arbitrary values", () => {
     const { css } = await t.uno.generate(classes);
     expect(css).toMatchSnapshot();
   });
+  test('min-height with rem unit', async (t) => {
+    const classes = ['min-h-[20000rem]', 'min-h-[99999rem]', 'min-h-[378rem]'];
+
+    const { css } = await t.uno.generate(classes);
+    expect(css).toMatchSnapshot();
+  });
   test('min-height with pixel values', async () => {
     const classes = ['min-h-[20000]', 'min-h-[99999]', 'min-h-[378]'];
 
@@ -136,8 +178,14 @@ describe("min width and height with arbitrary values", () => {
     const { css } = await uno.generate(classes);
     expect(css).toMatchSnapshot();
   });
+  test('min-height with pixel unit', async (t) => {
+    const classes = ['min-h-[20000px]', 'min-h-[99999px]', 'min-h-[378px]'];
+
+    const { css } = await t.uno.generate(classes);
+    expect(css).toMatchSnapshot();
+  });
   test('min-height with invalid value', async (t) => {
-    const classes = ['min-h-20000', 'min-h-99999', 'min-h-378', 'min-h-[20000a]', 'min-h-[99999rem]', 'min-h-[378px]'];
+    const classes = ['min-h-20000', 'min-h-99999', 'min-h-378', 'min-h-[20000a]'];
 
     const { css } = await t.uno.generate(classes);
     expect(css).toMatchInlineSnapshot('""');
@@ -151,6 +199,12 @@ describe("max width and height with arbitrary values", () => {
     const { css } = await t.uno.generate(classes);
     expect(css).toMatchSnapshot();
   });
+  test('max-width with rem unit', async (t) => {
+    const classes = ['max-w-[20000rem]', 'max-w-[99999rem]', 'max-w-[378rem]'];
+
+    const { css } = await t.uno.generate(classes);
+    expect(css).toMatchSnapshot();
+  });
   test('max-width with pixel values', async () => {
     const classes = ['max-w-[20000]', 'max-w-[99999]', 'max-w-[378]'];
 
@@ -158,8 +212,14 @@ describe("max width and height with arbitrary values", () => {
     const { css } = await uno.generate(classes);
     expect(css).toMatchSnapshot();
   });
+  test('max-width with pixel unit', async (t) => {
+    const classes = ['max-w-[20000px]', 'max-w-[99999px]', 'max-w-[378px]'];
+
+    const { css } = await t.uno.generate(classes);
+    expect(css).toMatchSnapshot();
+  });
   test('max-width with invalid value', async (t) => {
-    const classes = ['max-w-20000', 'max-w-99999', 'max-w-378', 'max-w-[20000a]', 'max-w-[99999rem]', 'max-w-[378px]'];
+    const classes = ['max-w-20000', 'max-w-99999', 'max-w-378', 'max-w-[20000a]'];
 
     const { css } = await t.uno.generate(classes);
     expect(css).toMatchInlineSnapshot('""');
@@ -171,6 +231,12 @@ describe("max width and height with arbitrary values", () => {
     const { css } = await t.uno.generate(classes);
     expect(css).toMatchSnapshot();
   });
+  test('max-height with rem unit', async (t) => {
+    const classes = ['max-h-[20000rem]', 'max-h-[99999rem]', 'max-h-[378rem]'];
+
+    const { css } = await t.uno.generate(classes);
+    expect(css).toMatchSnapshot();
+  });
   test('max-height with pixel values', async () => {
     const classes = ['max-h-[20000]', 'max-h-[99999]', 'max-h-[378]'];
 
@@ -178,8 +244,14 @@ describe("max width and height with arbitrary values", () => {
     const { css } = await uno.generate(classes);
     expect(css).toMatchSnapshot();
   });
+  test('max-height with pixel unit', async (t) => {
+    const classes = ['max-h-[20000px]', 'max-h-[99999px]', 'max-h-[378px]'];
+
+    const { css } = await t.uno.generate(classes);
+    expect(css).toMatchSnapshot();
+  });
   test('max-height with invalid value', async (t) => {
-    const classes = ['max-h-20000', 'max-h-99999', 'max-h-378', 'max-h-[20000a]', 'max-h-[99999rem]', 'max-h-[378px]'];
+    const classes = ['max-h-20000', 'max-h-99999', 'max-h-378', 'max-h-[20000a]'];
 
     const { css } = await t.uno.generate(classes);
     expect(css).toMatchInlineSnapshot('""');

--- a/test/size.js
+++ b/test/size.js
@@ -1,4 +1,4 @@
-import { setup, getFractions } from './_helpers.js';
+import { setup, getFractions, getGenerator } from './_helpers.js';
 import { spaceBase } from '#theme';
 import { describe, expect, test } from 'vitest';
 
@@ -61,39 +61,41 @@ describe('min width and height', () => {
 
 
 describe("width and height with arbitrary values", () => {
-  test('width', async (t) => {
+  test('width with rem values', async (t) => {
     const classes = ['w-[20000]', 'w-[99999]', 'w-[378]'];
 
     const { css } = await t.uno.generate(classes);
     expect(css).toMatchSnapshot();
   });
-  test('width', async (t) => {
-    const classes = ['w-[20000a]', 'w-[99999rem]', 'w-[378px]'];
+  test('width with pixel values', async () => {
+    const classes = ['w-[20000]', 'w-[99999]', 'w-[378]'];
+
+    const uno = getGenerator({ usePixels: true });
+    const { css } = await uno.generate(classes);
+    expect(css).toMatchSnapshot();
+  });
+  test('width with invalid value', async (t) => {
+    const classes = ['w-20000', 'w-99999', 'w-378', 'w-[20000a]', 'w-[99999rem]', 'w-[378px]'];
 
     const { css } = await t.uno.generate(classes);
     expect(css).toMatchInlineSnapshot('""');
   });
-  test('width with invalid non-arbitrary value', async (t) => {
-    const classes = ['w-20000', 'w-99999', 'w-378'];
 
-    const { css } = await t.uno.generate(classes);
-    expect(css).toMatchInlineSnapshot('""');
-  });
-  test('height', async (t) => {
+  test('height with rem values', async (t) => {
     const classes = ['h-[20000]', 'h-[99999]', 'h-[378]'];
 
     const { css } = await t.uno.generate(classes);
     expect(css).toMatchSnapshot();
   });
-  test('height with invalid arbitrary value', async (t) => {
-    const classes = ['h-[20000a]', 'h-[99999rem]', 'h-[378px]'];
+  test('height with pixel values', async () => {
+    const classes = ['h-[20000]', 'h-[99999]', 'h-[378]'];
 
-    const { css } = await t.uno.generate(classes);
-    expect(css).toMatchInlineSnapshot('""');
+    const uno = getGenerator({ usePixels: true });
+    const { css } = await uno.generate(classes);
+    expect(css).toMatchSnapshot();
   });
-
-  test('height with invalid non-arbitrary value', async (t) => {
-    const classes = ['h-20000', 'h-99999', 'h-378'];
+  test('height with invalid value', async (t) => {
+    const classes = ['h-20000', 'h-99999', 'h-378', 'h-[20000a]', 'h-[99999rem]', 'h-[378px]'];
 
     const { css } = await t.uno.generate(classes);
     expect(css).toMatchInlineSnapshot('""');
@@ -101,39 +103,41 @@ describe("width and height with arbitrary values", () => {
 });
 
 describe("min width and height with arbitrary values", () => {
-  test('min-width', async (t) => {
+  test('min-width with rem values', async (t) => {
     const classes = ['min-w-[20000]', 'min-w-[99999]', 'min-w-[378]'];
 
     const { css } = await t.uno.generate(classes);
     expect(css).toMatchSnapshot();
   });
-  test('min-width', async (t) => {
-    const classes = ['min-w-[20000a]', 'min-w-[99999rem]', 'min-w-[378px]'];
+  test('min-width with pixel values', async () => {
+    const classes = ['min-w-[20000]', 'min-w-[99999]', 'min-w-[378]'];
+
+    const uno = getGenerator({ usePixels: true });
+    const { css } = await uno.generate(classes);
+    expect(css).toMatchSnapshot();
+  });
+  test('min-width with invalid value', async (t) => {
+    const classes = ['min-w-20000', 'min-w-99999', 'min-w-378', 'min-w-[20000a]', 'min-w-[99999rem]', 'min-w-[378px]'];
 
     const { css } = await t.uno.generate(classes);
     expect(css).toMatchInlineSnapshot('""');
   });
-  test('min-width with invalid non-arbitrary value', async (t) => {
-    const classes = ['min-w-20000', 'min-w-99999', 'min-w-378'];
 
-    const { css } = await t.uno.generate(classes);
-    expect(css).toMatchInlineSnapshot('""');
-  });
-  test('min-height', async (t) => {
+  test('min-height with rem values', async (t) => {
     const classes = ['min-h-[20000]', 'min-h-[99999]', 'min-h-[378]'];
 
     const { css } = await t.uno.generate(classes);
     expect(css).toMatchSnapshot();
   });
-  test('min-height with invalid arbitrary value', async (t) => {
-    const classes = ['min-h-[20000a]', 'min-h-[99999rem]', 'min-h-[378px]'];
+  test('min-height with pixel values', async () => {
+    const classes = ['min-h-[20000]', 'min-h-[99999]', 'min-h-[378]'];
 
-    const { css } = await t.uno.generate(classes);
-    expect(css).toMatchInlineSnapshot('""');
+    const uno = getGenerator({ usePixels: true });
+    const { css } = await uno.generate(classes);
+    expect(css).toMatchSnapshot();
   });
-
-  test('min-height with invalid non-arbitrary value', async (t) => {
-    const classes = ['min-h-20000', 'min-h-99999', 'min-h-378'];
+  test('min-height with invalid value', async (t) => {
+    const classes = ['min-h-20000', 'min-h-99999', 'min-h-378', 'min-h-[20000a]', 'min-h-[99999rem]', 'min-h-[378px]'];
 
     const { css } = await t.uno.generate(classes);
     expect(css).toMatchInlineSnapshot('""');
@@ -141,39 +145,41 @@ describe("min width and height with arbitrary values", () => {
 });
 
 describe("max width and height with arbitrary values", () => {
-  test('max-width', async (t) => {
+  test('max-width with rem values', async (t) => {
     const classes = ['max-w-[20000]', 'max-w-[99999]', 'max-w-[378]'];
 
     const { css } = await t.uno.generate(classes);
     expect(css).toMatchSnapshot();
   });
-  test('max-width', async (t) => {
-    const classes = ['max-w-[20000a]', 'max-w-[99999rem]', 'max-w-[378px]'];
+  test('max-width with pixel values', async () => {
+    const classes = ['max-w-[20000]', 'max-w-[99999]', 'max-w-[378]'];
+
+    const uno = getGenerator({ usePixels: true });
+    const { css } = await uno.generate(classes);
+    expect(css).toMatchSnapshot();
+  });
+  test('max-width with invalid value', async (t) => {
+    const classes = ['max-w-20000', 'max-w-99999', 'max-w-378', 'max-w-[20000a]', 'max-w-[99999rem]', 'max-w-[378px]'];
 
     const { css } = await t.uno.generate(classes);
     expect(css).toMatchInlineSnapshot('""');
   });
-  test('max-width with invalid non-arbitrary value', async (t) => {
-    const classes = ['max-w-20000', 'max-w-99999', 'max-w-378'];
 
-    const { css } = await t.uno.generate(classes);
-    expect(css).toMatchInlineSnapshot('""');
-  });
-  test('max-height', async (t) => {
+  test('max-height with rem values', async (t) => {
     const classes = ['max-h-[20000]', 'max-h-[99999]', 'max-h-[378]'];
 
     const { css } = await t.uno.generate(classes);
     expect(css).toMatchSnapshot();
   });
-  test('max-height with invalid arbitrary value', async (t) => {
-    const classes = ['max-h-[20000a]', 'max-h-[99999rem]', 'max-h-[378px]'];
+  test('max-height with pixel values', async () => {
+    const classes = ['max-h-[20000]', 'max-h-[99999]', 'max-h-[378]'];
 
-    const { css } = await t.uno.generate(classes);
-    expect(css).toMatchInlineSnapshot('""');
+    const uno = getGenerator({ usePixels: true });
+    const { css } = await uno.generate(classes);
+    expect(css).toMatchSnapshot();
   });
-
-  test('max-height with invalid non-arbitrary value', async (t) => {
-    const classes = ['max-h-20000', 'max-h-99999', 'max-h-378'];
+  test('max-height with invalid value', async (t) => {
+    const classes = ['max-h-20000', 'max-h-99999', 'max-h-378', 'max-h-[20000a]', 'max-h-[99999rem]', 'max-h-[378px]'];
 
     const { css } = await t.uno.generate(classes);
     expect(css).toMatchInlineSnapshot('""');


### PR DESCRIPTION
### Description
This PR adds support for arbitrary values for (max/min-)width/height classes.
Examples:
- `min-w-[400]`, 
- `min-w-[40rem]`,
- `max-h-[400]`, 
- `max-h-[400px]`,
- `w-[70]`, 
- `h-[70]`,
- `h-[70px]`,
- `h-[7rem]`

The number values default to `rem` but we also support generating values in `px` based on`theme.usePixels` boolean.

### Required action:
- [x] - [Update documentation](https://warp-ds.github.io/css-docs/max-height#arbitrary-values)
