### PR TITLE
Add support for providing options from terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,11 @@
 1. Check out the `parity` project from warp-ds, get dependencies for the project
 2. Link to the `parity` project from the `plugin` folder (this folder): `pnpm link ../parity`
 3. Run `node checkFabricClasses.js`
+
+## generating warp classes using command line
+
+Run `node dev.js` or `pnpm dev`
+  Usage:
+    node dev.js [-c <string> | --cliClasses=<string>] [--usePixels] [--development] [--externalClasses] [--externalizeClasses] [--usePreflight]
+    Example: `node dev.js --usePixels --development --cliClasses=m-2`
+      ! Do not use shortcut when passing negative values, e.g. `node dev.js --cliClasses='-m-2! gap-2'`

--- a/dev.js
+++ b/dev.js
@@ -1,9 +1,20 @@
 import { createGenerator } from '@unocss/core';
 import { presetWarp } from '#plugin';
 
-const uno = createGenerator({ presets: [presetWarp()] });
+const options = {};
+const cliClasses = [];
+
+process.argv.slice(2).map(t => {
+  if (t.startsWith('--')) {
+    const option = t.replace('--', '');
+    options[option] = true;
+  } else {
+    cliClasses.push(t);
+  }
+});
+
+const uno = createGenerator({ presets: [presetWarp(options)] });
 const devClasses = ['m-16!', 'opacity-50'];
-const cliClasses = process.argv.slice(2);
 const classes = cliClasses.length ? cliClasses : devClasses;
 const result = await uno.generate(classes);
 console.log(result.css);

--- a/dev.js
+++ b/dev.js
@@ -1,20 +1,36 @@
+import { parseArgs } from 'node:util';
 import { createGenerator } from '@unocss/core';
 import { presetWarp } from '#plugin';
 
-const options = {};
-const cliClasses = [];
 
-process.argv.slice(2).map(t => {
-  if (t.startsWith('--')) {
-    const option = t.replace('--', '');
-    options[option] = true;
-  } else {
-    cliClasses.push(t);
-  }
+const {
+  values: { cliClasses, ...options },
+} = parseArgs({
+  options: {
+    cliClasses: {
+      type: 'string',
+      short: 'c',
+    },
+    development: {
+      type: 'boolean',
+    },
+    externalClasses: {
+      type: 'boolean',
+    },
+    externalizeClasses: {
+      type: 'boolean',
+    },
+    usePixels: {
+      type: 'boolean',
+    },
+    usePreflight: {
+      type: 'boolean',
+    },
+  },
 });
 
-const uno = createGenerator({ presets: [presetWarp(options)] });
+const uno = createGenerator({ presets: [presetWarp( options )] });
 const devClasses = ['m-16!', 'opacity-50'];
-const classes = cliClasses.length ? cliClasses : devClasses;
+const classes = cliClasses ?? devClasses;
 const result = await uno.generate(classes);
 console.log(result.css);


### PR DESCRIPTION
Before we could run `node dev.js 'gap-2'` to get the output like(default to rem) 👇 
```
/* layer: default */
.gap-2{gap:0.2rem;}
```

We still can do the above but now we can also provide an option with `--` prefix to use it in the theme. More info in the README
Like that(use pixels instead of rem) -> `node dev.js --usePixels --cliClasses '-m-2! gap-2'`
```
/* layer: default */
.gap-2{gap:2px;}
```

More usages: `node dev.js --usePixels --development --cliClasses '-m-2! gap-2'`