### PR TITLE
Fix linting on unformatted files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 .idea/
+.vscode

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -16,9 +16,9 @@ import { postprocess } from '#postprocess';
 // TODO: improve generic type passed here
 /** @type {import('@unocss/core').Preset<object>} */
 export function presetWarp (options = {}) {
-  const hasPreflight = options.usePreflight ?? options.development
-  const externalizeClasses = options.externalizeClasses ?? !options.development
-  const externalClasses = options.externalClasses ?? [] // will possibly be our own list in the future
+  const hasPreflight = options.usePreflight ?? options.development;
+  const externalizeClasses = options.externalizeClasses ?? !options.development;
+  const externalClasses = options.externalClasses ?? []; // will possibly be our own list in the future
   const theme = useTheme(options);
   return {
     name: '@warp-ds/uno',
@@ -26,7 +26,7 @@ export function presetWarp (options = {}) {
     rules,
     variants,
     preflights: hasPreflight ? preflights : [],
-    postprocess: postprocess(externalizeClasses, externalClasses)
+    postprocess: postprocess(externalizeClasses, externalClasses),
   };
 }
 

--- a/src/postprocessor.js
+++ b/src/postprocessor.js
@@ -1,15 +1,15 @@
-import { escapeSelector } from '@unocss/core'
+import { escapeSelector } from '@unocss/core';
 
-const prefix = 'w-'
-const classify = (str) => `.${escapeSelector(str)}`
+const prefix = 'w-';
+const classify = (str) => `.${escapeSelector(str)}`;
 
 export const postprocess = (shouldExternalize, _externalClasses = []) => {
-  const externalClasses = _externalClasses.map(classify)
+  const externalClasses = _externalClasses.map(classify);
   return (obj) => {
-    if (shouldExternalize && externalClasses.includes(obj.selector)) return obj.entries = null
+    if (shouldExternalize && externalClasses.includes(obj.selector)) return obj.entries = null;
     obj.entries.forEach(e => {
       e[0] = e[0].replace(/^--un-/, `--${prefix}`);
       if (typeof e[1] === "string") e[1] = e[1].replace(/var\(--un-/g, `var(--${prefix}`);
-    })
-  }
-}
+    });
+  };
+};

--- a/test/general.js
+++ b/test/general.js
@@ -48,5 +48,5 @@ test('it can externalize classes', async () => {
     "/* layer: default */
     .bottom-4{bottom:0.4rem;}
     .pt-8{padding-top:0.8rem;}"
-  `)
-})
+  `);
+});


### PR DESCRIPTION
Separate PR to avoid pollution in other PRs :) Might help if we set up formatting on save in our IDEs. 

The following fixes it in VSCode
In `.vscode/settings.json`:
```
{
  "editor.codeActionsOnSave": {
    "source.fixAll.eslint": true
   },
  "eslint.validate": ["javascript"]
}
```