### PR TITLE
Rules and tests for divide border

### DIFF
--- a/src/_rules/border.js
+++ b/src/_rules/border.js
@@ -1,3 +1,4 @@
+import { escapeSelector } from '@unocss/core';
 import { directionMap, cornerMap } from "#utils";
 
 const borderStyles = [
@@ -22,11 +23,12 @@ export const borders = [
   [/^border()-(.+)$/, handlerBorderStyle, { autocomplete: "(border)-style" }],
   [/^border-([xy])-(.+)$/, handlerBorderStyle],
   [/^border-([rltb])-(.+)$/, handlerBorderStyle],
+  // divide
+  [/^divide-([xy])-?(\d+)?$/, handlerDivideBorder],
 ];
 
 function handlerBorder(m, ctx) {
   const borderSizes = handlerBorderSize(m, ctx);
-
   if (borderSizes ) return [...borderSizes];
 }
 
@@ -50,4 +52,24 @@ export const rounded = [
 function handlerRounded([, a = '', s], { theme }) {
   const v = theme.borderRadius?.[s ?? 4];
   if (a in cornerMap && v != null) return cornerMap[a].map(i => [`border${i}-radius`, v]);
+}
+
+function handleDivideBorderSizes(direction, width, theme) {
+  const borderWidth = theme.lineWidth?.[width ?? 1];
+  if (direction in directionMap && borderWidth) {
+    return directionMap[direction].map((i) => {
+      if (i === directionMap[direction][1]) {
+        return `border${i}-width:0px`;
+      }
+      return `border${i}-width:${borderWidth}`;
+    });
+  };
+}
+
+function handlerDivideBorder([_selector, direction = "", width], { theme }) {
+  const sizes = handleDivideBorderSizes(direction, width, theme)?.join(';');
+  if (sizes) {
+    const selector = escapeSelector(_selector);
+    return `.${selector}>*+*{${sizes}}`;
+  }
 }

--- a/src/_rules/border.js
+++ b/src/_rules/border.js
@@ -1,5 +1,6 @@
 import { escapeSelector } from '@unocss/core';
 import { directionMap, cornerMap } from "#utils";
+import { lineWidth } from '#theme';
 
 const borderStyles = [
   "solid",
@@ -24,7 +25,7 @@ export const borders = [
   [/^border-([xy])-(.+)$/, handlerBorderStyle],
   [/^border-([rltb])-(.+)$/, handlerBorderStyle],
   // divide
-  [/^divide-([xy])-?(\d+)?$/, handlerDivideBorder],
+  [/^divide-([xy])-?(\d+)?-?(reverse)?$/, handlerDivideBorder, { autocomplete: `divide-<x|y>-(${Object.keys(lineWidth).join('|')})-(reverse)` }],
 ];
 
 function handlerBorder(m, ctx) {
@@ -54,20 +55,21 @@ function handlerRounded([, a = '', s], { theme }) {
   if (a in cornerMap && v != null) return cornerMap[a].map(i => [`border${i}-radius`, v]);
 }
 
-function handleDivideBorderSizes(direction, width, theme) {
+function handleDivideBorderSizes(direction, width, reverse, theme) {
   const borderWidth = theme.lineWidth?.[width ?? 1];
   if (direction in directionMap && borderWidth) {
     return directionMap[direction].map((i) => {
-      if (i === directionMap[direction][1]) {
-        return `border${i}-width:0px`;
+      const borderPosition = !!reverse ? 0 : 1;
+      if (i === directionMap[direction][borderPosition]) {
+        return `border${i}-width:0`;
       }
       return `border${i}-width:${borderWidth}`;
     });
   };
 }
 
-function handlerDivideBorder([_selector, direction = "", width], { theme }) {
-  const sizes = handleDivideBorderSizes(direction, width, theme)?.join(';');
+function handlerDivideBorder([_selector, direction = "", width, reverse], { theme }) {
+  const sizes = handleDivideBorderSizes(direction, width, reverse, theme)?.join(';');
   if (sizes) {
     const selector = escapeSelector(_selector);
     return `.${selector}>*+*{${sizes}}`;

--- a/src/_rules/border.js
+++ b/src/_rules/border.js
@@ -30,6 +30,7 @@ export const borders = [
 
 function handlerBorder(m, ctx) {
   const borderSizes = handlerBorderSize(m, ctx);
+
   if (borderSizes ) return [...borderSizes];
 }
 

--- a/src/theme.js
+++ b/src/theme.js
@@ -24,7 +24,7 @@ const zIndex = {
   50: "50",
 };
 
-const lineWidth = {
+export const lineWidth = {
   0: "0",
   1: "1px",
   2: "2px",

--- a/test/__snapshots__/border.js.snap
+++ b/test/__snapshots__/border.js.snap
@@ -24,6 +24,20 @@ exports[`border > right, left, top bottom 1`] = `
 .border-t-8{border-top-width:8px;}"
 `;
 
+exports[`border > supports divide borders between horizontal and stacked children 1`] = `
+"/* layer: default */
+.divide-x-0>*+*{border-left-width:0;border-right-width:0px}
+.divide-x-1>*+*{border-left-width:1px;border-right-width:0px}
+.divide-x-2>*+*{border-left-width:2px;border-right-width:0px}
+.divide-x-4>*+*{border-left-width:4px;border-right-width:0px}
+.divide-x-8>*+*{border-left-width:8px;border-right-width:0px}
+.divide-y-0>*+*{border-top-width:0;border-bottom-width:0px}
+.divide-y-1>*+*{border-top-width:1px;border-bottom-width:0px}
+.divide-y-2>*+*{border-top-width:2px;border-bottom-width:0px}
+.divide-y-4>*+*{border-top-width:4px;border-bottom-width:0px}
+.divide-y-8>*+*{border-top-width:8px;border-bottom-width:0px}"
+`;
+
 exports[`border > supports setting border style 1`] = `
 "/* layer: default */
 .border-dashed{border-style:dashed;}

--- a/test/__snapshots__/border.js.snap
+++ b/test/__snapshots__/border.js.snap
@@ -52,6 +52,14 @@ exports[`border > supports divide borders between horizontal and stacked childre
 .divide-y-8-reverse>*+*{border-top-width:0;border-bottom-width:8px}"
 `;
 
+exports[`border > supports divide borders between horizontal and stacked children, default width 1`] = `
+"/* layer: default */
+.divide-x-reverse>*+*{border-left-width:0;border-right-width:1px}
+.divide-x>*+*{border-left-width:1px;border-right-width:0}
+.divide-y-reverse>*+*{border-top-width:0;border-bottom-width:1px}
+.divide-y>*+*{border-top-width:1px;border-bottom-width:0}"
+`;
+
 exports[`border > supports setting border style 1`] = `
 "/* layer: default */
 .border-dashed{border-style:dashed;}

--- a/test/__snapshots__/border.js.snap
+++ b/test/__snapshots__/border.js.snap
@@ -26,16 +26,30 @@ exports[`border > right, left, top bottom 1`] = `
 
 exports[`border > supports divide borders between horizontal and stacked children 1`] = `
 "/* layer: default */
-.divide-x-0>*+*{border-left-width:0;border-right-width:0px}
-.divide-x-1>*+*{border-left-width:1px;border-right-width:0px}
-.divide-x-2>*+*{border-left-width:2px;border-right-width:0px}
-.divide-x-4>*+*{border-left-width:4px;border-right-width:0px}
-.divide-x-8>*+*{border-left-width:8px;border-right-width:0px}
-.divide-y-0>*+*{border-top-width:0;border-bottom-width:0px}
-.divide-y-1>*+*{border-top-width:1px;border-bottom-width:0px}
-.divide-y-2>*+*{border-top-width:2px;border-bottom-width:0px}
-.divide-y-4>*+*{border-top-width:4px;border-bottom-width:0px}
-.divide-y-8>*+*{border-top-width:8px;border-bottom-width:0px}"
+.divide-x-0>*+*{border-left-width:0;border-right-width:0}
+.divide-x-1>*+*{border-left-width:1px;border-right-width:0}
+.divide-x-2>*+*{border-left-width:2px;border-right-width:0}
+.divide-x-4>*+*{border-left-width:4px;border-right-width:0}
+.divide-x-8>*+*{border-left-width:8px;border-right-width:0}
+.divide-y-0>*+*{border-top-width:0;border-bottom-width:0}
+.divide-y-1>*+*{border-top-width:1px;border-bottom-width:0}
+.divide-y-2>*+*{border-top-width:2px;border-bottom-width:0}
+.divide-y-4>*+*{border-top-width:4px;border-bottom-width:0}
+.divide-y-8>*+*{border-top-width:8px;border-bottom-width:0}"
+`;
+
+exports[`border > supports divide borders between horizontal and stacked children in reverse order 1`] = `
+"/* layer: default */
+.divide-x-0-reverse>*+*{border-left-width:0;border-right-width:0}
+.divide-x-1-reverse>*+*{border-left-width:0;border-right-width:1px}
+.divide-x-2-reverse>*+*{border-left-width:0;border-right-width:2px}
+.divide-x-4-reverse>*+*{border-left-width:0;border-right-width:4px}
+.divide-x-8-reverse>*+*{border-left-width:0;border-right-width:8px}
+.divide-y-0-reverse>*+*{border-top-width:0;border-bottom-width:0}
+.divide-y-1-reverse>*+*{border-top-width:0;border-bottom-width:1px}
+.divide-y-2-reverse>*+*{border-top-width:0;border-bottom-width:2px}
+.divide-y-4-reverse>*+*{border-top-width:0;border-bottom-width:4px}
+.divide-y-8-reverse>*+*{border-top-width:0;border-bottom-width:8px}"
 `;
 
 exports[`border > supports setting border style 1`] = `

--- a/test/border.js
+++ b/test/border.js
@@ -89,13 +89,20 @@ describe("border", () => {
     expect(css).toMatchSnapshot();
   });
 
-});
+  test('supports divide borders between horizontal and stacked children in reverse order', async ({ uno }) => {
+    const classes = Object.keys(lineWidth).map(width => [`divide-x-${width}-reverse`, `divide-y-${width}-reverse`]).flat();
 
-test('does not support divide borders when invalid width provided', async ({ uno }) => {
-  const classes = ['divide-x-10', 'divide-y-hej', 'divide-z-2'];
+    const { css } = await uno.generate(classes);
+    expect(css).toMatchSnapshot();
+  });
 
-  const { css } = await uno.generate(classes);
-  expect(css).toMatchInlineSnapshot('""');
+  test('does not support divide borders when invalid width provided', async ({ uno }) => {
+    const classes = ['divide-x-10', 'divide-y-hej', 'divide-z-2-not-reverse'];
+
+    const { css } = await uno.generate(classes);
+    expect(css).toMatchInlineSnapshot('""');
+  });
+
 });
 
 describe("rounded", () => {

--- a/test/border.js
+++ b/test/border.js
@@ -1,5 +1,6 @@
 import { setup } from "./_helpers.js";
 import { describe, expect, test } from "vitest";
+import { lineWidth } from '#theme';
 
 setup();
 
@@ -81,6 +82,20 @@ describe("border", () => {
 
     expect(css).toMatchSnapshot();
   });
+  test('supports divide borders between horizontal and stacked children', async ({ uno }) => {
+    const classes = Object.keys(lineWidth).map(width => [`divide-x-${width}`, `divide-y-${width}`]).flat();
+
+    const { css } = await uno.generate(classes);
+    expect(css).toMatchSnapshot();
+  });
+
+});
+
+test('does not support divide borders when invalid width provided', async ({ uno }) => {
+  const classes = ['divide-x-10', 'divide-y-hej', 'divide-z-2'];
+
+  const { css } = await uno.generate(classes);
+  expect(css).toMatchInlineSnapshot('""');
 });
 
 describe("rounded", () => {

--- a/test/border.js
+++ b/test/border.js
@@ -82,6 +82,7 @@ describe("border", () => {
 
     expect(css).toMatchSnapshot();
   });
+
   test('supports divide borders between horizontal and stacked children', async ({ uno }) => {
     const classes = Object.keys(lineWidth).map(width => [`divide-x-${width}`, `divide-y-${width}`]).flat();
 
@@ -93,6 +94,11 @@ describe("border", () => {
     const classes = Object.keys(lineWidth).map(width => [`divide-x-${width}-reverse`, `divide-y-${width}-reverse`]).flat();
 
     const { css } = await uno.generate(classes);
+    expect(css).toMatchSnapshot();
+  });
+
+  test('supports divide borders between horizontal and stacked children, default width', async ({ uno }) => {
+    const { css } = await uno.generate(['divide-x', 'divide-y', 'divide-x-reverse', 'divide-y-reverse']);
     expect(css).toMatchSnapshot();
   });
 


### PR DESCRIPTION
Inspired by: https://tailwindcss.com/docs/divide-width

![image](https://user-images.githubusercontent.com/37986637/220905816-a1fa10a5-4a99-4d48-8473-8a249050ca9d.png)


Added support for `divide-x|y-{0-8}-{reverse} > * + *`

Arbitrary values are not supported yet, will create a separate task for it.