### PR TITLE
Remove helper function for array creation, feels unnecessary

### DIFF
--- a/test/_helpers.js
+++ b/test/_helpers.js
@@ -17,7 +17,3 @@ export const getFractions = (prefix, length = 6) => {
     return `${prefix}-${n}/${d}`;
   })).filter(Boolean);
 };
-
-export function getNumericArrayInRange(first, last) {
-  return Array.from({ length: last - first + 1 }, (_, index) => first + index);
-}

--- a/test/flex.js
+++ b/test/flex.js
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { setup, getNumericArrayInRange } from './_helpers.js';
+import { setup } from './_helpers.js';
 
 setup();
 
@@ -59,9 +59,8 @@ test('flex invalid', async (t) => {
 });
 
 test('flex shrink/grow', async (t) => {
-  const boundsRangeArray  = getNumericArrayInRange(0, 5);
   const autoClasses = ['grow', 'shrink'];
-  const classes = boundsRangeArray.map((num) => [`shrink-${num}`, `grow-${num}`]).flat();
+  const classes = Array.from({ length: 6 }, (_, index) => [`shrink-${index}`, `grow-${index}`]).flat();
 
   const { css } = await t.uno.generate([...classes, ...autoClasses]);
   expect(css).toMatchInlineSnapshot(`

--- a/test/grid.js
+++ b/test/grid.js
@@ -1,10 +1,10 @@
 import { expect, test } from 'vitest';
-import { setup, getNumericArrayInRange } from './_helpers.js';
+import { setup } from './_helpers.js';
 
 setup();
 
-const columns = getNumericArrayInRange(1, 13);
-const rows = getNumericArrayInRange(1, 7);
+const columns = Array.from({ length: 13 }, (_, index) => 1 + index);
+const rows = Array.from({ length: 7 }, (_, index) => 1 + index);
 
 test('grid span', async (t) => {
   const staticClasses = [

--- a/test/line-clamp.js
+++ b/test/line-clamp.js
@@ -1,11 +1,11 @@
-import { setup, getNumericArrayInRange } from "./_helpers.js";
+import { setup } from "./_helpers.js";
 import { describe, expect, test } from "vitest";
 
 setup();
 
 describe('line-clamp', () => {
   test('should render styles for static classes', async ({ uno }) => {
-    const staticClasses = getNumericArrayInRange(1, 9).map(n => `line-clamp-${n}`);
+    const staticClasses = Array.from({ length: 9 }, (_, index) => `line-clamp-${1 + index}`);
     const { css } = await uno.generate(staticClasses);
     expect(css).toMatchSnapshot();
   });


### PR DESCRIPTION
It doesn't feel necessary to have this function anymore. No need for double iteration imho either.
This PR addresses [this comment](https://github.com/warp-ds/drive/pull/60#discussion_r1121463008) as well.

Does these changes make sense?
