### PR TITLE
chore: add beta and next branches to prereleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - master
       - alpha
+      - beta
+      - next
 jobs:
   release:
     name: Release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,10 @@
 {
-  "branches": [{ "name": "master" }, { "name": "alpha", "prerelease": true }],
+  "branches": [
+    { "name": "master" },
+    { "name": "alpha", "prerelease": true },
+    { "name": "beta", "prerelease": true },
+    { "name": "next", "prerelease": true }
+  ],
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",


### PR DESCRIPTION
Add `beta` and `next` to the release workflow in case we decide to name the prerelease branch something else, like they did in [eik plugin for semantic-release](https://github.com/eik-lib/semantic-release/blob/master/.github/workflows/publish.yml#L7-L9).