### PR TITLE
feat(internals): add rules for border-top/right/bottom/left-color classes

### DIFF
--- a/src/_rules/internal.js
+++ b/src/_rules/internal.js
@@ -4,7 +4,7 @@ export const internalRules = [
   [/^i-bg-(.+)$/, ([, cssvar]) => ({ 'background-color': h.warpToken(cssvar) })],
   [/^i-text-(.+)$/, ([, cssvar]) => ({ color: h.warpToken(cssvar) })],
   [/^i-border-(.+)$/, ([, cssvar]) => ({ 'border-color': h.warpToken(cssvar) })],
-  [/^i-border-([rltb])-(.+)$/, ([_, direction, cssvar]) => {
+  [/^i-border-([rltb])-(.+)$/, ([, direction, cssvar]) => {
     if (direction in directionMap && cssvar != null) {
       return directionMap[direction].map(
         (dir) => [`border${dir}-color`, h.warpToken(cssvar)],

--- a/src/_rules/internal.js
+++ b/src/_rules/internal.js
@@ -1,7 +1,14 @@
-import { handler as h } from '#utils';
+import { handler as h, directionMap } from '#utils';
 
 export const internalRules = [
   [/^i-bg-(.+)$/, ([, cssvar]) => ({ 'background-color': h.warpToken(cssvar) })],
   [/^i-text-(.+)$/, ([, cssvar]) => ({ color: h.warpToken(cssvar) })],
   [/^i-border-(.+)$/, ([, cssvar]) => ({ 'border-color': h.warpToken(cssvar) })],
+  [/^i-border-([rltb])-(.+)$/, ([_, direction, cssvar]) => {
+    if (direction in directionMap && cssvar != null) {
+      return directionMap[direction].map(
+        (dir) => [`border${dir}-color`, h.warpToken(cssvar)],
+      );
+    }
+  }],
 ];

--- a/test/__snapshots__/internal.js.snap
+++ b/test/__snapshots__/internal.js.snap
@@ -4,5 +4,9 @@ exports[`it generates css based on warp tokens 1`] = `
 "/* layer: default */
 .i-bg-\\\\$foo-bar{background-color:var(--w-foo-bar);}
 .i-text-\\\\$biz-baz{color:var(--w-biz-baz);}
-.i-border-\\\\$wombat-llama{border-color:var(--w-wombat-llama);}"
+.i-border-\\\\$wombat-llama{border-color:var(--w-wombat-llama);}
+.i-border-b-\\\\$color-alert-info-border{border-bottom-color:var(--w-color-alert-info-border);}
+.i-border-l-\\\\$color-alert-info-border{border-left-color:var(--w-color-alert-info-border);}
+.i-border-r-\\\\$color-alert-info-border{border-right-color:var(--w-color-alert-info-border);}
+.i-border-t-\\\\$color-alert-info-border{border-top-color:var(--w-color-alert-info-border);}"
 `;

--- a/test/internal.js
+++ b/test/internal.js
@@ -4,8 +4,26 @@ import { expect, test } from 'vitest';
 setup();
 
 test('it generates css based on warp tokens', async ({ uno }) => {
-  const classes = ['i-bg-$foo-bar', 'i-text-$biz-baz', 'i-border-$wombat-llama'];
-  const anticlasses = ['i-bg-foos-bars', 'i-text-bizs-bazs', 'i-border-wombats-llamas', 'i-magnuseses'];
+  const classes = [
+    'i-bg-$foo-bar',
+    'i-text-$biz-baz',
+    'i-border-$wombat-llama',
+    'i-border-l-$color-alert-info-border',
+    'i-border-r-$color-alert-info-border',
+    'i-border-t-$color-alert-info-border',
+    'i-border-b-$color-alert-info-border',
+  ];
+  const anticlasses = [
+    'i-bg-foos-bars',
+    'i-text-bizs-bazs',
+    'i-border-wombats-llamas',
+    'i-magnuseses',
+    'i-border-tr-$color-alert-info-border',
+    'i-border-br-$color-alert-info-border',
+    'i-border-tl-$color-alert-info-border',
+    'i-border-bl-$color-alert-info-border',
+    'i-border-tbl-$color-alert-info-border',
+  ];
   const { css } = await uno.generate([...classes, ...anticlasses]);
   expect(css).toMatchSnapshot();
 });


### PR DESCRIPTION
We've had rules for border width and style for different sides (top/right/bottom/left) and now we also have rules for internal classes that target color of those borders.