### PR TITLE
chore(border): remove redundant rounded rule

### DIFF
--- a/src/_rules/border.js
+++ b/src/_rules/border.js
@@ -48,7 +48,6 @@ function handlerBorderStyle([, a = "", s]) {
 export const rounded = [
   [/^rounded()(?:-(.+))?$/, handlerRounded, { autocomplete: ['(rounded)', '(rounded)-<num>'] }],
   [/^rounded-([rltb]+)(?:-(.+))?$/, handlerRounded],
-  [/^rounded([rltb]{2})(?:-(.+))?$/, handlerRounded],
   [/^rounded-([bi][se])(?:-(.+))?$/, handlerRounded],
   [/^rounded-([bi][se]-[bi][se])(?:-(.+))?$/, handlerRounded],
 ];


### PR DESCRIPTION
Removed rules that target classes like `roundedt-2` or `roundedbl-4`.
`[/^rounded-([rltb]+)(?:-(.+))?$/, handlerRounded]` targets all rounded classes we need to target.
