### PR TITLE
fix: height and width shouldn't match without a dash

### DIFF
--- a/src/_rules/size.js
+++ b/src/_rules/size.js
@@ -24,7 +24,7 @@ function getSizeValue(minmax, hw, theme, prop) {
 
 export const sizes = [
   [
-    /^(min-|max-)?([wh])-?(.+)$/,
+    /^(min-|max-)?([wh])-(.+)$/,
     ([, minmax, wOrH, s], { theme }) => ({ [getPropName(minmax, wOrH)]: getSizeValue(minmax, wOrH, theme, s) }),
     {
       autocomplete: [

--- a/test/size.js
+++ b/test/size.js
@@ -14,12 +14,20 @@ describe('width and height', () => {
     const { css } = await uno.generate(classes);
     expect(css).toMatchSnapshot();
   });
+  test(`width without dash shouldn't match`, async ({ uno }) => {
+    const { css } = await uno.generate(['w2', 'w32']);
+    expect(css).toMatchInlineSnapshot('""');
+  });
   test('height', async ({ uno }) => {
     const classes = spaceBase.map(e => `h-${e}`);
     classes.push(...getSpecialSuffixes('h'));
     classes.push(...getFractions('h'));
     const { css } = await uno.generate(classes);
     expect(css).toMatchSnapshot();
+  });
+  test(`height without dash shouldn't match`, async ({ uno }) => {
+    const { css } = await uno.generate(['h2', 'h32']);
+    expect(css).toMatchInlineSnapshot('""');
   });
 });
 


### PR DESCRIPTION
Rules like `h32` were matching, which makes it so both `h-32` and `h32` would have the same effect - and it would be ideal to have 'one true way' of writing these.

Slightly worse, Fabric has `h1`, `h2`, and `h3` (f.ex), and this matching would cause these to temporarily look very broken as users migrate.