### PR TITLE
fix: add rules and tests for caret

### DIFF
--- a/src/_rules/color.js
+++ b/src/_rules/color.js
@@ -2,16 +2,23 @@ export const opacity = [
   [/^opacity-(\d+)$/, ([, d], { theme }) => ({ opacity: theme.opacity[d] }), { autocomplete: 'opacity-${opacity}' }],
 ];
 
+export const caretColors = [
+  ['caret', { 'caret-color': 'var(--w-color-input-caret)' }],
+  ['caret-inherit', { 'caret-color': 'inherit'  }],
+  ['caret-current', { 'caret-color': 'currentColor' }],
+  ['caret-transparent', { 'caret-color': 'transparent' }],
+];
+
 export const textColors = [
-  ['text', { color: 'var(--w-text-color)' }],
-  ['text-inverted', { color: 'var(--w-text-color-inverted)' }],
-  ['text-inverted-subtle', { color: 'var(--w-text-color-inverted-subtle)' }],
-  ['text-subtle', { color: 'var(--w-text-color-subtle)' }],
+  ['text', { color: 'var(--w-color-text)' }],
+  ['text-inverted', { color: 'var(--w-color-text-inverted)' }],
+  ['text-inverted-subtle', { color: 'var(--w-color-text-inverted-subtle)' }],
+  ['text-subtle', { color: 'var(--w-color-text-subtle)' }],
 ];
 
 export const bgColors = [
-  ['bg', { 'background-color': 'var(--w-background-color)' }],
-  ['bg-subtle', { 'background-color': 'var(--w-background-color-subtle)' }],
+  ['bg', { 'background-color': 'var(--w-color-background)' }],
+  ['bg-subtle', { 'background-color': 'var(--w-color-background-subtle)' }],
   ['bg-inherit', { 'background-color': 'inherit' }],
   ['bg-transparent', { 'background-color': 'transparent' }],
   ['bg-current', { 'background-color': 'currentColor' }],

--- a/test/__snapshots__/color.js.snap
+++ b/test/__snapshots__/color.js.snap
@@ -2,11 +2,19 @@
 
 exports[`bg colors 1`] = `
 "/* layer: default */
-.bg{background-color:var(--w-background-color);}
-.bg-subtle{background-color:var(--w-background-color-subtle);}
+.bg{background-color:var(--w-color-background);}
+.bg-subtle{background-color:var(--w-color-background-subtle);}
 .bg-inherit{background-color:inherit;}
 .bg-transparent{background-color:transparent;}
 .bg-current{background-color:currentColor;}"
+`;
+
+exports[`caret 1`] = `
+"/* layer: default */
+.caret{caret-color:var(--w-color-input-caret);}
+.caret-inherit{caret-color:inherit;}
+.caret-current{caret-color:currentColor;}
+.caret-transparent{caret-color:transparent;}"
 `;
 
 exports[`opacity by theme 1`] = `
@@ -19,8 +27,8 @@ exports[`opacity by theme 1`] = `
 
 exports[`text colors 1`] = `
 "/* layer: default */
-.text{color:var(--w-text-color);}
-.text-inverted{color:var(--w-text-color-inverted);}
-.text-inverted-subtle{color:var(--w-text-color-inverted-subtle);}
-.text-subtle{color:var(--w-text-color-subtle);}"
+.text{color:var(--w-color-text);}
+.text-inverted{color:var(--w-color-text-inverted);}
+.text-inverted-subtle{color:var(--w-color-text-inverted-subtle);}
+.text-subtle{color:var(--w-color-text-subtle);}"
 `;

--- a/test/color.js
+++ b/test/color.js
@@ -51,3 +51,15 @@ test('bg color invalid class', async({ uno }) => {
   const { css } = await uno.generate(classes);
   expect(css).toMatchInlineSnapshot('""');
 });
+
+test('caret', async({ uno }) => {
+  const classes = [
+    'caret',
+    'caret-inherit',
+    'caret-current',
+    'caret-transparent',
+  ];
+
+  const { css } = await uno.generate(classes);
+  expect(css).toMatchSnapshot();
+});


### PR DESCRIPTION
We needed to add a rules for https://github.com/fabric-ds/css/blob/49b07c05686ef132b203026e941bf04dbab6fc7a/src/components/form-elements.css#L14 to be able to add `caret-color`.

!Also changed old tokens after the renaming!