### PR TITLE
fix: add correct token for the focus ring

### DIFF
--- a/src/_rules/focus-ring.js
+++ b/src/_rules/focus-ring.js
@@ -1,6 +1,6 @@
 // TODO: use actual variables and values when those has been defined
 const focusRingStyle = {
-  'outline': '2px solid var(--w-outline)',
+  'outline': '2px solid var(--w-color-focused)',
   'outline-offset': 'var(--w-outline-offset, 1px)',
 };
 

--- a/test/focus-ring.js
+++ b/test/focus-ring.js
@@ -16,7 +16,7 @@ test("focus ring", async (t) => {
   expect(css).toMatchInlineSnapshot(`
     "/* layer: default */
     .focusable\\\\:focus,
-    .focusable\\\\:focus-visible{outline:2px solid var(--w-outline);outline-offset:var(--w-outline-offset, 1px);}
+    .focusable\\\\:focus-visible{outline:2px solid var(--w-color-focused);outline-offset:var(--w-outline-offset, 1px);}
     .focusable\\\\:focus\\\\:not\\\\(\\\\:focus-visible\\\\){outline:none;}
     .focusable-inset{--w-outline-offset:-3px;}"
   `);


### PR DESCRIPTION
Use correct token from the spreadsheet:
<img width="580" alt="image" src="https://user-images.githubusercontent.com/37986637/234018902-b201a6cd-368f-469e-91c6-776ce87997f4.png">
TODO is left though as the offset token is not changed, yet