### PR TITLE
fix: be able to use a one-off background image

### DIFF
--- a/src/_rules/background.js
+++ b/src/_rules/background.js
@@ -36,4 +36,7 @@ export const backgrounds = [
   ['bg-origin-padding', { 'background-origin': 'padding-box' }],
   ['bg-origin-content', { 'background-origin': 'content-box' }],
   ...makeGlobalStaticRules('bg-origin', 'background-origin'),
+
+  //arbitrary
+  [/^bg-\[url\('(.+)'\)]/, ([, p]) => ({ 'background-image': `url(${p})` })],
 ];

--- a/test/background.js
+++ b/test/background.js
@@ -51,3 +51,12 @@ test('bg invalid', async ({ uno }) => {
   const { css } = await uno.generate(classes);
   expect(css).toMatchInlineSnapshot('""');
 });
+
+test('bg arbitrary url', async ({ uno }) => {
+  const classes = [`bg-[url('/img/hero-pattern.svg')]`];
+  const { css } = await uno.generate(classes);
+  expect(css).toMatchInlineSnapshot(`
+    "/* layer: default */
+    .bg-\\\\[url\\\\(\\\\'\\\\/img\\\\/hero-pattern\\\\.svg\\\\'\\\\)\\\\]{background-image:url(/img/hero-pattern.svg);}"
+  `);
+});


### PR DESCRIPTION
We need to add support for an arbitrary one off background image.
Mentioned [here](https://warp-ds.github.io/css-docs/background-image#arbitrary-values) and is for now needed in the toggle component