### PR TITLE
feat(internals): add rules for shadow component classes

### DIFF
--- a/src/_rules/internal.js
+++ b/src/_rules/internal.js
@@ -4,7 +4,7 @@ export const internalRules = [
   [/^i-bg-(.+)$/, ([, cssvar]) => ({ 'background-color': h.warpToken(cssvar) })],
   [/^i-text-(.+)$/, ([, cssvar]) => ({ color: h.warpToken(cssvar) })],
   [/^i-border-(.+)$/, ([, cssvar]) => ({ 'border-color': h.warpToken(cssvar) })],
-  [/^i-elevation-(.+)$/, ([, cssvar]) => ({ 'box-shadow': h.warpToken(cssvar) })],
+  [/^i-shadow-(.+)$/, ([, cssvar]) => ({ 'box-shadow': h.warpToken(cssvar) })],
   [/^i-border-([rltb])-(.+)$/, ([, direction, cssvar]) => {
     if (direction in directionMap && cssvar != null) {
       return directionMap[direction].map(

--- a/src/_rules/internal.js
+++ b/src/_rules/internal.js
@@ -4,6 +4,7 @@ export const internalRules = [
   [/^i-bg-(.+)$/, ([, cssvar]) => ({ 'background-color': h.warpToken(cssvar) })],
   [/^i-text-(.+)$/, ([, cssvar]) => ({ color: h.warpToken(cssvar) })],
   [/^i-border-(.+)$/, ([, cssvar]) => ({ 'border-color': h.warpToken(cssvar) })],
+  [/^i-elevation-(.+)$/, ([, cssvar]) => ({ 'box-shadow': h.warpToken(cssvar) })],
   [/^i-border-([rltb])-(.+)$/, ([, direction, cssvar]) => {
     if (direction in directionMap && cssvar != null) {
       return directionMap[direction].map(

--- a/test/__snapshots__/internal.js.snap
+++ b/test/__snapshots__/internal.js.snap
@@ -5,9 +5,9 @@ exports[`it generates css based on warp tokens 1`] = `
 .i-bg-\\\\$foo-bar{background-color:var(--w-foo-bar);}
 .i-text-\\\\$biz-baz{color:var(--w-biz-baz);}
 .i-border-\\\\$wombat-llama{border-color:var(--w-wombat-llama);}
-.i-elevation-\\\\$shadow-buttongroup{box-shadow:var(--w-shadow-buttongroup);}
-.i-elevation-\\\\$shadow-card{box-shadow:var(--w-shadow-card);}
-.i-elevation-\\\\$shadow-tooltip{box-shadow:var(--w-shadow-tooltip);}
+.i-shadow-\\\\$shadow-buttongroup{box-shadow:var(--w-shadow-buttongroup);}
+.i-shadow-\\\\$shadow-card{box-shadow:var(--w-shadow-card);}
+.i-shadow-\\\\$shadow-tooltip{box-shadow:var(--w-shadow-tooltip);}
 .i-border-b-\\\\$color-alert-info-border{border-bottom-color:var(--w-color-alert-info-border);}
 .i-border-l-\\\\$color-alert-info-border{border-left-color:var(--w-color-alert-info-border);}
 .i-border-r-\\\\$color-alert-info-border{border-right-color:var(--w-color-alert-info-border);}

--- a/test/__snapshots__/internal.js.snap
+++ b/test/__snapshots__/internal.js.snap
@@ -5,6 +5,9 @@ exports[`it generates css based on warp tokens 1`] = `
 .i-bg-\\\\$foo-bar{background-color:var(--w-foo-bar);}
 .i-text-\\\\$biz-baz{color:var(--w-biz-baz);}
 .i-border-\\\\$wombat-llama{border-color:var(--w-wombat-llama);}
+.i-elevation-\\\\$shadow-buttongroup{box-shadow:var(--w-shadow-buttongroup);}
+.i-elevation-\\\\$shadow-card{box-shadow:var(--w-shadow-card);}
+.i-elevation-\\\\$shadow-tooltip{box-shadow:var(--w-shadow-tooltip);}
 .i-border-b-\\\\$color-alert-info-border{border-bottom-color:var(--w-color-alert-info-border);}
 .i-border-l-\\\\$color-alert-info-border{border-left-color:var(--w-color-alert-info-border);}
 .i-border-r-\\\\$color-alert-info-border{border-right-color:var(--w-color-alert-info-border);}

--- a/test/internal.js
+++ b/test/internal.js
@@ -12,6 +12,9 @@ test('it generates css based on warp tokens', async ({ uno }) => {
     'i-border-r-$color-alert-info-border',
     'i-border-t-$color-alert-info-border',
     'i-border-b-$color-alert-info-border',
+    'i-elevation-$shadow-card',
+    'i-elevation-$shadow-buttongroup',
+    'i-elevation-$shadow-tooltip',
   ];
   const anticlasses = [
     'i-bg-foos-bars',
@@ -23,6 +26,8 @@ test('it generates css based on warp tokens', async ({ uno }) => {
     'i-border-tl-$color-alert-info-border',
     'i-border-bl-$color-alert-info-border',
     'i-border-tbl-$color-alert-info-border',
+    'i-$shadow-card',
+    'i-shadow-$shadow-card',
   ];
   const { css } = await uno.generate([...classes, ...anticlasses]);
   expect(css).toMatchSnapshot();

--- a/test/internal.js
+++ b/test/internal.js
@@ -12,9 +12,9 @@ test('it generates css based on warp tokens', async ({ uno }) => {
     'i-border-r-$color-alert-info-border',
     'i-border-t-$color-alert-info-border',
     'i-border-b-$color-alert-info-border',
-    'i-elevation-$shadow-card',
-    'i-elevation-$shadow-buttongroup',
-    'i-elevation-$shadow-tooltip',
+    'i-shadow-$shadow-card',
+    'i-shadow-$shadow-buttongroup',
+    'i-shadow-$shadow-tooltip',
   ];
   const anticlasses = [
     'i-bg-foos-bars',
@@ -27,7 +27,7 @@ test('it generates css based on warp tokens', async ({ uno }) => {
     'i-border-bl-$color-alert-info-border',
     'i-border-tbl-$color-alert-info-border',
     'i-$shadow-card',
-    'i-shadow-$shadow-card',
+    'i-elevation-$shadow-card',
   ];
   const { css } = await uno.generate([...classes, ...anticlasses]);
   expect(css).toMatchSnapshot();


### PR DESCRIPTION
Generate box-shadow css for component classes that rely on component-specific shadow tokens.