### PR TITLE
fix(shadows): add default box-shadow values to generic shadow classes

### DIFF
--- a/src/_rules/shadow.js
+++ b/src/_rules/shadow.js
@@ -1,6 +1,12 @@
+const defaultColor = 'rgba(0, 0, 0 , .2)';
+
+const boxShadowDefaults = {
+  small: `0 1px 6px ${defaultColor}, 0 1px 1px ${defaultColor}`,
+  medium: `0 3px 8px ${defaultColor}, 0 3px 6px ${defaultColor}`,
+  large: `0 6px 8px ${defaultColor}, 0 10px 20px ${defaultColor}`,
+  xlarge: `0 9px 12px ${defaultColor}, 0 14px 28px ${defaultColor}`,
+};
+
 export const shadows = [
-  ['shadow-small', { 'box-shadow': 'var(--w-shadow-small)' }],
-  ['shadow-medium', { 'box-shadow': 'var(--w-shadow-medium)' }],
-  ['shadow-large', { 'box-shadow': 'var(--w-shadow-large)' }],
-  ['shadow-xlarge', { 'box-shadow': 'var(--w-shadow-xlarge)' }],
+  [/^shadow-(small|medium|large|xlarge)$/, ([, size]) => ({ 'box-shadow': `var(--w-shadow-${size}, ${boxShadowDefaults[size]})` })],
 ];

--- a/src/_rules/shadow.js
+++ b/src/_rules/shadow.js
@@ -1,4 +1,4 @@
-const defaultColor = 'rgba(0, 0, 0 , .2)';
+const defaultColor = 'rgba(0, 0, 0, .2)';
 
 const boxShadowDefaults = {
   small: `0 1px 6px ${defaultColor}, 0 1px 1px ${defaultColor}`,

--- a/test/__snapshots__/shadow.js.snap
+++ b/test/__snapshots__/shadow.js.snap
@@ -2,8 +2,8 @@
 
 exports[`shadows work 1`] = `
 "/* layer: default */
-.shadow-large{box-shadow:var(--w-shadow-large, 0 6px 8px rgba(0, 0, 0 , .2), 0 10px 20px rgba(0, 0, 0 , .2));}
-.shadow-medium{box-shadow:var(--w-shadow-medium, 0 3px 8px rgba(0, 0, 0 , .2), 0 3px 6px rgba(0, 0, 0 , .2));}
-.shadow-small{box-shadow:var(--w-shadow-small, 0 1px 6px rgba(0, 0, 0 , .2), 0 1px 1px rgba(0, 0, 0 , .2));}
-.shadow-xlarge{box-shadow:var(--w-shadow-xlarge, 0 9px 12px rgba(0, 0, 0 , .2), 0 14px 28px rgba(0, 0, 0 , .2));}"
+.shadow-large{box-shadow:var(--w-shadow-large, 0 6px 8px rgba(0, 0, 0, .2), 0 10px 20px rgba(0, 0, 0, .2));}
+.shadow-medium{box-shadow:var(--w-shadow-medium, 0 3px 8px rgba(0, 0, 0, .2), 0 3px 6px rgba(0, 0, 0, .2));}
+.shadow-small{box-shadow:var(--w-shadow-small, 0 1px 6px rgba(0, 0, 0, .2), 0 1px 1px rgba(0, 0, 0, .2));}
+.shadow-xlarge{box-shadow:var(--w-shadow-xlarge, 0 9px 12px rgba(0, 0, 0, .2), 0 14px 28px rgba(0, 0, 0, .2));}"
 `;

--- a/test/__snapshots__/shadow.js.snap
+++ b/test/__snapshots__/shadow.js.snap
@@ -2,8 +2,8 @@
 
 exports[`shadows work 1`] = `
 "/* layer: default */
-.shadow-small{box-shadow:var(--w-shadow-small);}
-.shadow-medium{box-shadow:var(--w-shadow-medium);}
-.shadow-large{box-shadow:var(--w-shadow-large);}
-.shadow-xlarge{box-shadow:var(--w-shadow-xlarge);}"
+.shadow-large{box-shadow:var(--w-shadow-large, 0 6px 8px rgba(0, 0, 0 , .2), 0 10px 20px rgba(0, 0, 0 , .2));}
+.shadow-medium{box-shadow:var(--w-shadow-medium, 0 3px 8px rgba(0, 0, 0 , .2), 0 3px 6px rgba(0, 0, 0 , .2));}
+.shadow-small{box-shadow:var(--w-shadow-small, 0 1px 6px rgba(0, 0, 0 , .2), 0 1px 1px rgba(0, 0, 0 , .2));}
+.shadow-xlarge{box-shadow:var(--w-shadow-xlarge, 0 9px 12px rgba(0, 0, 0 , .2), 0 14px 28px rgba(0, 0, 0 , .2));}"
 `;


### PR DESCRIPTION
Added Finn shadow values as default to generic shadow rules based on [this thread](https://sch-chat.slack.com/archives/C050N3NQ204/p1682607264763969?thread_ts=1682339766.883849&cid=C050N3NQ204).