### PR TITLE
feat(slider): add border shadow for active and hover states

### DIFF
--- a/src/_rules/index.js
+++ b/src/_rules/index.js
@@ -18,6 +18,7 @@ import * as list from "./list.js";
 import * as position from "./position.js";
 import * as shadow from "./shadow.js";
 import * as size from "./size.js";
+import * as slider from "./slider.js";
 import * as spaceMargin from './space-margin.js';
 import * as spacing from "./spacing.js";
 import * as staticRules from "./static.js";
@@ -47,6 +48,7 @@ const ruleGroups = {
   ...position,
   ...shadow,
   ...size,
+  ...slider,
   ...spaceMargin,
   ...spacing,
   ...staticRules,
@@ -81,6 +83,7 @@ export * from "./size.js";
 export * from './space-margin.js';
 export * from "./spacing.js";
 export * from "./static.js";
+export * from "./slider.js";
 export * from "./table.js";
 export * from "./transform.js";
 export * from "./transition.js";

--- a/src/_rules/slider.js
+++ b/src/_rules/slider.js
@@ -1,0 +1,15 @@
+// Hardcoded styling for slider border shadow, will be modified and handled with correct color variables at a later stage
+const defaultColor = 'rgba(0, 0, 0, .08)';
+const sliderStates = {
+  active: '0 0 0 8px',
+  hover: '0 0 0 6px',
+};
+
+export const sliderHandleShadow = [
+  [
+    /^slider-handle-shadow-(active|hover)$/,
+    ([, state]) => ({
+      'box-shadow': `${sliderStates[state]} ${defaultColor})`,
+    }),
+  ],
+];

--- a/src/_rules/slider.js
+++ b/src/_rules/slider.js
@@ -1,4 +1,5 @@
 // Hardcoded styling for slider border shadow, will be modified and handled with correct color variables at a later stage
+// TODO: Make the colors for the slider shadow themeable
 const defaultColor = 'rgba(0, 0, 0, .08)';
 const sliderStates = {
   active: '0 0 0 8px',

--- a/test/__snapshots__/slider.js.snap
+++ b/test/__snapshots__/slider.js.snap
@@ -1,0 +1,15 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`slider > get active slider shadow  1`] = `
+"/* layer: default */
+.slider-handle-shadow-active{box-shadow:0 0 0 8px rgba(0, 0, 0, .08));}"
+`;
+
+exports[`slider > get hover slider shadow  1`] = `
+"/* layer: default */
+.slider-handle-shadow-hover{box-shadow:0 0 0 6px rgba(0, 0, 0, .08));}"
+`;
+
+exports[`slider > get hower shadow 1`] = `""`;
+
+exports[`slider > get slider shadow 1`] = `""`;

--- a/test/slider.js
+++ b/test/slider.js
@@ -1,0 +1,16 @@
+import { setup } from './_helpers.js';
+import { describe, expect, test } from 'vitest';
+
+setup();
+
+describe('slider', () => {
+  test('get active slider shadow ', async ({ uno }) => {
+    const { css } = await uno.generate(['slider-handle-shadow-active']);
+    expect(css).toMatchSnapshot();
+  });
+
+  test('get hover slider shadow ', async ({ uno }) => {
+    const { css } = await uno.generate(['slider-handle-shadow-hover']);
+    expect(css).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
This PR includes hard coded classnames for the slide thumb. 
The current solution is not supported by theming, and has the same color for all themes. 

The difference from fabric is that the shadow is gray instead of blue. 