### PR TITLE
fix(slider): fix slider bug

### DIFF
--- a/src/_rules/slider.js
+++ b/src/_rules/slider.js
@@ -10,7 +10,7 @@ export const sliderHandleShadow = [
   [
     /^slider-handle-shadow-(active|hover)$/,
     ([, state]) => ({
-      'box-shadow': `${sliderStates[state]} ${defaultColor})`,
+      'box-shadow': `${sliderStates[state]} ${defaultColor}`,
     }),
   ],
 ];

--- a/src/_rules/slider.js
+++ b/src/_rules/slider.js
@@ -1,3 +1,5 @@
+import { entriesToCss } from '@unocss/core';
+
 // Hardcoded styling for slider border shadow, will be modified and handled with correct color variables at a later stage
 // TODO: Make the colors for the slider shadow themeable
 const defaultColor = 'rgba(0, 0, 0, .08)';
@@ -12,5 +14,17 @@ export const sliderHandleShadow = [
     ([, state]) => ({
       'box-shadow': `${sliderStates[state]} ${defaultColor}`,
     }),
+  ],
+];
+
+export const sliderOutlineStyles = entriesToCss(Object.entries({
+  outline: '2px solid rgba(0, 0, 0, 0)',
+  'outline-offset': '2px',
+}));
+
+export const sliderOutlineNone = [
+  [
+    /^slider-outline-none$/,
+    () => (sliderOutlineStyles),
   ],
 ];

--- a/src/_rules/slider.js
+++ b/src/_rules/slider.js
@@ -1,5 +1,3 @@
-import { entriesToCss } from '@unocss/core';
-
 // Hardcoded styling for slider border shadow, will be modified and handled with correct color variables at a later stage
 // TODO: Make the colors for the slider shadow themeable
 const defaultColor = 'rgba(0, 0, 0, .08)';
@@ -14,17 +12,5 @@ export const sliderHandleShadow = [
     ([, state]) => ({
       'box-shadow': `${sliderStates[state]} ${defaultColor}`,
     }),
-  ],
-];
-
-export const sliderOutlineStyles = entriesToCss(Object.entries({
-  outline: '2px solid rgba(0, 0, 0, 0)',
-  'outline-offset': '2px',
-}));
-
-export const sliderOutlineNone = [
-  [
-    /^slider-outline-none$/,
-    () => (sliderOutlineStyles),
   ],
 ];

--- a/test/__snapshots__/slider.js.snap
+++ b/test/__snapshots__/slider.js.snap
@@ -5,11 +5,26 @@ exports[`slider > get active slider shadow  1`] = `
 .slider-handle-shadow-active{box-shadow:0 0 0 8px rgba(0, 0, 0, .08));}"
 `;
 
+exports[`slider > get active slider shadow 1`] = `
+"/* layer: default */
+.slider-handle-shadow-active{box-shadow:0 0 0 8px rgba(0, 0, 0, .08);}"
+`;
+
 exports[`slider > get hover slider shadow  1`] = `
 "/* layer: default */
 .slider-handle-shadow-hover{box-shadow:0 0 0 6px rgba(0, 0, 0, .08));}"
 `;
 
+exports[`slider > get hover slider shadow 1`] = `
+"/* layer: default */
+.slider-handle-shadow-hover{box-shadow:0 0 0 6px rgba(0, 0, 0, .08);}"
+`;
+
 exports[`slider > get hower shadow 1`] = `""`;
 
 exports[`slider > get slider shadow 1`] = `""`;
+
+exports[`slider > get styling for slider outline none 1`] = `
+"/* layer: default */
+outline:2px solid rgba(0, 0, 0, 0);outline-offset:2px;"
+`;

--- a/test/__snapshots__/slider.js.snap
+++ b/test/__snapshots__/slider.js.snap
@@ -1,30 +1,11 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`slider > get active slider shadow  1`] = `
-"/* layer: default */
-.slider-handle-shadow-active{box-shadow:0 0 0 8px rgba(0, 0, 0, .08));}"
-`;
-
 exports[`slider > get active slider shadow 1`] = `
 "/* layer: default */
 .slider-handle-shadow-active{box-shadow:0 0 0 8px rgba(0, 0, 0, .08);}"
 `;
 
-exports[`slider > get hover slider shadow  1`] = `
-"/* layer: default */
-.slider-handle-shadow-hover{box-shadow:0 0 0 6px rgba(0, 0, 0, .08));}"
-`;
-
 exports[`slider > get hover slider shadow 1`] = `
 "/* layer: default */
 .slider-handle-shadow-hover{box-shadow:0 0 0 6px rgba(0, 0, 0, .08);}"
-`;
-
-exports[`slider > get hower shadow 1`] = `""`;
-
-exports[`slider > get slider shadow 1`] = `""`;
-
-exports[`slider > get styling for slider outline none 1`] = `
-"/* layer: default */
-outline:2px solid rgba(0, 0, 0, 0);outline-offset:2px;"
 `;

--- a/test/slider.js
+++ b/test/slider.js
@@ -16,7 +16,6 @@ describe('slider', () => {
 
   test('get styling for slider outline none', async ({ uno }) => {
     const { css } = await uno.generate(['slider-outline-none']);
-    console.log("css", css);
     expect(css).toMatchSnapshot();
   });
 });

--- a/test/slider.js
+++ b/test/slider.js
@@ -4,13 +4,19 @@ import { describe, expect, test } from 'vitest';
 setup();
 
 describe('slider', () => {
-  test('get active slider shadow ', async ({ uno }) => {
+  test('get active slider shadow', async ({ uno }) => {
     const { css } = await uno.generate(['slider-handle-shadow-active']);
     expect(css).toMatchSnapshot();
   });
 
-  test('get hover slider shadow ', async ({ uno }) => {
+  test('get hover slider shadow', async ({ uno }) => {
     const { css } = await uno.generate(['slider-handle-shadow-hover']);
+    expect(css).toMatchSnapshot();
+  });
+
+  test('get styling for slider outline none', async ({ uno }) => {
+    const { css } = await uno.generate(['slider-outline-none']);
+    console.log("css", css);
     expect(css).toMatchSnapshot();
   });
 });

--- a/test/slider.js
+++ b/test/slider.js
@@ -13,9 +13,4 @@ describe('slider', () => {
     const { css } = await uno.generate(['slider-handle-shadow-hover']);
     expect(css).toMatchSnapshot();
   });
-
-  test('get styling for slider outline none', async ({ uno }) => {
-    const { css } = await uno.generate(['slider-outline-none']);
-    expect(css).toMatchSnapshot();
-  });
 });


### PR DESCRIPTION
This PR includes:
- Remove one too many parentheses for `sliderHandleShadow` 
- Add styling specific for the `slider`: removes the outline of the thumb