### PR TITLE
feat(slider): add outline-none styling for slider

### DIFF
--- a/src/_rules/slider.js
+++ b/src/_rules/slider.js
@@ -14,3 +14,13 @@ export const sliderHandleShadow = [
     }),
   ],
 ];
+
+export const sliderOutlineNone = [
+  [
+    /^slider-handle-outline-none$/,
+    () => ({
+      outline: 'rgba(0, 0, 0, 0) solid 2px',
+      'outline-offset': '2px',
+    }),
+  ],
+];

--- a/test/__snapshots__/slider.js.snap
+++ b/test/__snapshots__/slider.js.snap
@@ -9,3 +9,13 @@ exports[`slider > get hover slider shadow 1`] = `
 "/* layer: default */
 .slider-handle-shadow-hover{box-shadow:0 0 0 6px rgba(0, 0, 0, .08);}"
 `;
+
+exports[`slider > get hover slider shadow 2`] = `
+"/* layer: default */
+.slider-handle-outline-none{outline:rgba(0, 0, 0, 0) solid 2px;outline-offset:2px;}"
+`;
+
+exports[`slider > get slider outline none 1`] = `
+"/* layer: default */
+.slider-handle-outline-none{outline:rgba(0, 0, 0, 0) solid 2px;outline-offset:2px;}"
+`;

--- a/test/slider.js
+++ b/test/slider.js
@@ -13,4 +13,9 @@ describe('slider', () => {
     const { css } = await uno.generate(['slider-handle-shadow-hover']);
     expect(css).toMatchSnapshot();
   });
+
+  test('get slider outline none', async ({ uno }) => {
+    const { css } = await uno.generate(['slider-handle-outline-none']);
+    expect(css).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
Styling specific for the slider. 
The outline styling is needed to make the focus state behave according to the design (the current design adds shadow and border)