### PR TITLE
feat: rule for adding safe area inset from the bottom edge of the viewport

### DIFF
--- a/src/_rules/static.js
+++ b/src/_rules/static.js
@@ -189,6 +189,7 @@ export const touchAction = [
 ];
 
 export const safeArea = [
-  ['pb-safe', { 'padding-bottom': 'calc(32px + env(safe-area-inset-bottom, 0px))' }],
+  ['pb-safe', { 'padding-bottom': 'env(safe-area-inset-bottom, 0px)' }],
   ['mb-safe', { 'margin-bottom': 'env(safe-area-inset-bottom, 0px)' }],
+  [/^pb-safe-\[([\d]+)]$/, ([, d]) =>  ({ 'padding-bottom': `calc(${d}px + env(safe-area-inset-bottom, 0px))` })],
 ];

--- a/src/_rules/static.js
+++ b/src/_rules/static.js
@@ -187,3 +187,8 @@ export const touchAction = [
   ['touch-pinch-zoom', { 'touch-action': 'pinch-zoom' }],
   ['touch-manipulation', { 'touch-action': 'manipulation' }],
 ];
+
+export const safeArea = [
+  ['pb-safe', { 'padding-bottom': 'calc(32px + env(safe-area-inset-bottom, 0px))' }],
+  ['mb-safe', { 'margin-bottom': 'env(safe-area-inset-bottom, 0px)' }],
+];

--- a/test/__snapshots__/static.js.snap
+++ b/test/__snapshots__/static.js.snap
@@ -153,7 +153,7 @@ exports[`static rules do static things 1`] = `
 .touch-pan-down{touch-action:pan-down;}
 .touch-pinch-zoom{touch-action:pinch-zoom;}
 .touch-manipulation{touch-action:manipulation;}
-.pb-safe{padding-bottom:calc(32px + env(safe-area-inset-bottom, 0px));}
+.pb-safe{padding-bottom:env(safe-area-inset-bottom, 0px);}
 .mb-safe{margin-bottom:env(safe-area-inset-bottom, 0px);}"
 `;
 
@@ -202,5 +202,6 @@ exports[`static rules for object position > supports all predefined values in th
 .object-tl,
 .object-top-left{object-position:top left;}
 .object-top-right,
-.object-tr{object-position:top right;}"
+.object-tr{object-position:top right;}
+.pb-safe-\\\\[32\\\\]{padding-bottom:calc(32px + env(safe-area-inset-bottom, 0px));}"
 `;

--- a/test/__snapshots__/static.js.snap
+++ b/test/__snapshots__/static.js.snap
@@ -152,7 +152,9 @@ exports[`static rules do static things 1`] = `
 .touch-pan-up{touch-action:pan-up;}
 .touch-pan-down{touch-action:pan-down;}
 .touch-pinch-zoom{touch-action:pinch-zoom;}
-.touch-manipulation{touch-action:manipulation;}"
+.touch-manipulation{touch-action:manipulation;}
+.pb-safe{padding-bottom:calc(32px + env(safe-area-inset-bottom, 0px));}
+.mb-safe{margin-bottom:env(safe-area-inset-bottom, 0px);}"
 `;
 
 exports[`static rules for object position > supports all predefined values in the position map 1`] = `

--- a/test/static.js
+++ b/test/static.js
@@ -16,7 +16,8 @@ test('static rules do static things', async ({ uno }) => {
 describe('static rules for object position', () => {
   test('supports all predefined values in the position map', async ({ uno }) => {
     const staticClasses = Object.keys(positionMap).map(position => `object-${position}`);
-    const { css } = await uno.generate(staticClasses);
+    const arbitraryClasses = ['pb-safe-[32]'];
+    const { css } = await uno.generate([...staticClasses, ...arbitraryClasses]);
     expect(css).toMatchSnapshot();
   });
   test('do not support invalid values', async ({ uno }) => {


### PR DESCRIPTION
While migrating styles for the modal the need of adding the safe inset appeared. 
Here are two code examples 👇 
https://github.com/fabric-ds/css/blob/next/src/components/modal.css#L16
https://github.com/fabric-ds/css/blob/01fd80a27461cf0d593911e974853f84963d0681/src/components/toast.css#L3

I couldn't find any suitable rule in unocss, only custom plugins. So I ended up creating our own rules. For the naming I got inspired by [this plugin](https://github.com/mvllow/tailwindcss-safe-area)

Wdyt?