### PR TITLE
feat(dropshadow): add drop shadow as a constant for use in attention

### DIFF
--- a/src/_rules/shadow.js
+++ b/src/_rules/shadow.js
@@ -10,3 +10,8 @@ const boxShadowDefaults = {
 export const shadows = [
   [/^shadow-(small|medium|large|xlarge)$/, ([, size]) => ({ 'box-shadow': `var(--w-shadow-${size}, ${boxShadowDefaults[size]})` })],
 ];
+
+
+export const dropShadow = [
+  [/^drop-shadow$/, () => ({ 'filter': 'drop-shadow(rgba(64, 64, 64, 0.24) 0px 3px 8px) drop-shadow(rgba(64, 64, 64, 0.16) 0px 3px 6px)' })],
+];

--- a/test/__snapshots__/shadow.js.snap
+++ b/test/__snapshots__/shadow.js.snap
@@ -1,5 +1,20 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`drop shadow s 1`] = `
+"/* layer: default */
+.drop-shadow{filter:drop-shadow(rgba(64, 64, 64, 0.24) 0px 3px 8px) drop-shadow(rgba(64, 64, 64, 0.16) 0px 3px 6px);}"
+`;
+
+exports[`drop shadow work 1`] = `
+"/* layer: default */
+.drop-shadow{filter:drop-shadow(rgba(64, 64, 64, 0.24) 0px 3px 8px) drop-shadow(rgba(64, 64, 64, 0.16) 0px 3px 6px);}"
+`;
+
+exports[`drop shadows 1`] = `
+"/* layer: default */
+.drop-shadow{filter:drop-shadow(rgba(64, 64, 64, 0.24) 0px 3px 8px) drop-shadow(rgba(64, 64, 64, 0.16) 0px 3px 6px);}"
+`;
+
 exports[`shadows work 1`] = `
 "/* layer: default */
 .shadow-large{box-shadow:var(--w-shadow-large, 0 6px 8px rgba(0, 0, 0, .2), 0 10px 20px rgba(0, 0, 0, .2));}

--- a/test/shadow.js
+++ b/test/shadow.js
@@ -8,3 +8,9 @@ test('shadows work', async ({ uno }) => {
   const { css } = await uno.generate(classes);
   expect(css).toMatchSnapshot();
 });
+
+test('drop shadows', async ({ uno }) => {
+  const classes = ['drop-shadow'];
+  const { css } = await uno.generate(classes);
+  expect(css).toMatchSnapshot();
+});


### PR DESCRIPTION
This PR includes a constant fix for `drop shadows`. 
the `filter: drop-shadow ...` is needed for the `attention popover` component

This will later be modified if we need it in other places. Should in that case later support dynamic rgba values, as for `shadows`