### PR TITLE
fix: improve syntax to clear the float for the elements after legend

### DIFF
--- a/src/_preflights/tw-reset.js
+++ b/src/_preflights/tw-reset.js
@@ -407,10 +407,10 @@ legend {
   margin: 0;
   padding: 0;
   width: 100%;
+}
 
-  & + * {
-    clear: both;
-  }
+legend + * {
+  clear: both;
 }
 
 fieldset {


### PR DESCRIPTION
I could reproduce issue in Firefox [here](https://warp-ds.github.io/tech-docs/components/checkbox/) and then in local Vue setup
Expected|What we got|Fixed
---|---|---
![image](https://github.com/warp-ds/drive/assets/37986637/1ef0e9c8-db6f-4bbe-bb91-df01bc2f85b9)|![image](https://github.com/warp-ds/drive/assets/37986637/5fb56327-18f0-4bac-9207-68d2097492f9)|![image](https://github.com/warp-ds/drive/assets/37986637/7059ce2c-4118-4912-b400-9b3001fad63b)

