### PR TITLE
fix: focusable classes

### DIFF
--- a/src/_rules/focus-ring.js
+++ b/src/_rules/focus-ring.js
@@ -1,16 +1,24 @@
+import { entriesToCss } from '@unocss/core';
+
 // TODO: use actual variables and values when those has been defined
-const focusRingStyle = {
-  'outline': '2px solid var(--w-color-focused)',
+const focusRingStyle = entriesToCss(Object.entries({
+  outline: '2px solid var(--w-color-focused)',
   'outline-offset': 'var(--w-outline-offset, 1px)',
-};
+}));
+
+const outlineNone = entriesToCss(Object.entries({
+  outline: 'none',
+}));
 
 const focusRingInsetStyle = {
   '--w-outline-offset': '-3px',
 };
 
 export const focusRing = [
-  ["focusable:focus", focusRingStyle],
-  ["focusable:focus:not(:focus-visible)", { 'outline': 'none' }],
-  ["focusable:focus-visible", focusRingStyle],
+  [/^focusable$/, ([selector]) => {
+    const focus = `.${selector}:focus,.${selector}:focus-visible{${focusRingStyle}}`;
+    const notFocusVisible = `.${selector}:not(:focus-visible){${outlineNone}}`;
+    return focus + notFocusVisible;
+  }],
   ["focusable-inset", { ... focusRingInsetStyle }],
 ];

--- a/test/focus-ring.js
+++ b/test/focus-ring.js
@@ -5,9 +5,7 @@ setup();
 
 test("focus ring", async (t) => {
   const classes = [
-    "focusable:focus",
-    "focusable:focus:not(:focus-visible)",
-    "focusable:focus-visible",
+    "focusable",
     "focusable-inset",
   ];
 
@@ -15,9 +13,7 @@ test("focus ring", async (t) => {
 
   expect(css).toMatchInlineSnapshot(`
     "/* layer: default */
-    .focusable\\\\:focus,
-    .focusable\\\\:focus-visible{outline:2px solid var(--w-color-focused);outline-offset:var(--w-outline-offset, 1px);}
-    .focusable\\\\:focus\\\\:not\\\\(\\\\:focus-visible\\\\){outline:none;}
+    .focusable:focus,.focusable:focus-visible{outline:2px solid var(--w-color-focused);outline-offset:var(--w-outline-offset, 1px);}.focusable:not(:focus-visible){outline:none;}
     .focusable-inset{--w-outline-offset:-3px;}"
   `);
 });


### PR DESCRIPTION
Migrated fabric stuff from https://github.com/warp-ds/drive/blob/alpha/src/_rules/focus-ring.js but didn't work as we wished.

Before|After
---|---
![image](https://github.com/warp-ds/drive/assets/37986637/91bc13ff-7c81-4515-ad29-5d7c08ea3c76)|![image](https://github.com/warp-ds/drive/assets/37986637/f75acc4a-13ce-4c9a-b5d3-c0279ca1c625)
