### PR TITLE
fix: add page-container fully controlled rule

### DIFF
--- a/src/_rules/static.js
+++ b/src/_rules/static.js
@@ -1,3 +1,4 @@
+import { entriesToCss } from '@unocss/core';
 import { globalKeywords, handler as h, makeGlobalStaticRules, positionMap } from '#utils';
 
 export const appearances = [
@@ -192,4 +193,25 @@ export const safeArea = [
   ['pb-safe', { 'padding-bottom': 'env(safe-area-inset-bottom, 0px)' }],
   ['mb-safe', { 'margin-bottom': 'env(safe-area-inset-bottom, 0px)' }],
   [/^pb-safe-\[([\d]+)]$/, ([, d]) =>  ({ 'padding-bottom': `calc(${d}px + env(safe-area-inset-bottom, 0px))` })],
+];
+
+const pageContainerStyles = entriesToCss(Object.entries({
+  background: 'var(--w-color-background)',
+  margin: 0,
+  padding: '0 16px',
+  'max-width': '1010px',
+}));
+const wrapperBigScreenStyles = entriesToCss(Object.entries({
+  'margin-left': 'auto',
+  'margin-right': 'auto',
+  'padding-left': '31px',
+  'padding-right': '31px',
+}));
+
+export const pageContainter = [
+  [/^page-container$/, ([selector]) => {
+    const base = `.${selector}{${pageContainerStyles}}`;
+    const child = `@media (min-width: 1300px){.${selector}{${wrapperBigScreenStyles}}}`;
+    return base + child;
+  }],
 ];

--- a/test/__snapshots__/static.js.snap
+++ b/test/__snapshots__/static.js.snap
@@ -205,3 +205,8 @@ exports[`static rules for object position > supports all predefined values in th
 .object-tr{object-position:top right;}
 .pb-safe-\\\\[32\\\\]{padding-bottom:calc(32px + env(safe-area-inset-bottom, 0px));}"
 `;
+
+exports[`static rules for page-container 1`] = `
+"/* layer: default */
+.page-container{background:var(--w-color-background);margin:0;padding:0 16px;max-width:1010px;}@media (min-width: 1300px){.page-container{margin-left:auto;margin-right:auto;padding-left:31px;padding-right:31px;}}"
+`;

--- a/test/static.js
+++ b/test/static.js
@@ -13,6 +13,12 @@ test('static rules do static things', async ({ uno }) => {
   expect(css).toMatchSnapshot();
 });
 
+test('static rules for page-container', async ({ uno }) => {
+  const staticClasses = ['page-container'];
+  const { css } = await uno.generate(staticClasses);
+  expect(css).toMatchSnapshot();
+});
+
 describe('static rules for object position', () => {
   test('supports all predefined values in the position map', async ({ uno }) => {
     const staticClasses = Object.keys(positionMap).map(position => `object-${position}`);


### PR DESCRIPTION
A highly hardcoded `.page-container`. Styles moved from https://github.com/fabric-ds/css/blob/01fd80a27461cf0d593911e974853f84963d0681/src/components/page-container.css#L1. More info in the ticket linked