### PR TITLE
feat: add new shortcut for page-container

### DIFF
--- a/src/_shortcuts/index.js
+++ b/src/_shortcuts/index.js
@@ -1,3 +1,4 @@
+import { pageContainer } from './pageContainer.js';
 import { typographyAliases } from './typography.js';
 
-export const shortcuts = [typographyAliases];
+export const shortcuts = [typographyAliases, pageContainer];

--- a/src/_shortcuts/pageContainer.js
+++ b/src/_shortcuts/pageContainer.js
@@ -1,0 +1,1 @@
+export const pageContainer = { 'page-container': 'bg-[var(--w-color-background)] m-0 p-0 max-w-[1010px] pl-[16px] pr-[16px] lg:mx-auto lg:pl-[31px] lg:pr-[31px]' };

--- a/src/_shortcuts/pageContainer.js
+++ b/src/_shortcuts/pageContainer.js
@@ -1,1 +1,1 @@
-export const pageContainer = { 'page-container': 'bg-[var(--w-color-background)] m-0 p-0 max-w-[1010px] pl-[16px] pr-[16px] lg:mx-auto lg:pl-[31px] lg:pr-[31px]' };
+export const pageContainer = { 'page-container': 'bg-[var(--w-color-background)] m-0 p-0 max-w-[1010px] pl-[16px] pr-[16px] xl:mx-auto xl:pl-[31px] xl:pr-[31px]' };

--- a/src/theme.js
+++ b/src/theme.js
@@ -5,6 +5,8 @@ const breakpoints = {
   md: '768px',
   // lg hits full desktop-width and up
   lg: '990px',
+  // xl hits wide desktop-width and up
+  xl: '1300px',
 };
 
 const divideByTen = n => {


### PR DESCRIPTION
New shortcut for `page-container`. Styles moved from https://github.com/fabric-ds/css/blob/01fd80a27461cf0d593911e974853f84963d0681/src/components/page-container.css#L1. More info in the ticket linked

Tested in Vue|>1300px|<1300px
---|---|---
Tested in Vue|![image](https://github.com/warp-ds/drive/assets/37986637/13ae6c8f-ea0a-4ad9-baac-0c6afa97b7b6)|![image](https://github.com/warp-ds/drive/assets/37986637/46b432e9-23b9-49b8-a355-e37528342686)


