### PR TITLE
feat: Add background, text and border classes for semantic color tokens

### DIFF
--- a/src/_rules/index.js
+++ b/src/_rules/index.js
@@ -17,6 +17,7 @@ import * as layout from "./layout.js";
 import * as lineClamp from "./line-clamp.js";
 import * as list from "./list.js";
 import * as position from "./position.js";
+import * as semantic from './semantic.js';
 import * as shadow from "./shadow.js";
 import * as size from "./size.js";
 import * as slider from "./slider.js";
@@ -49,6 +50,7 @@ const ruleGroups = {
   ...lineClamp,
   ...list,
   ...position,
+  ...semantic,
   ...shadow,
   ...size,
   ...slider,
@@ -83,6 +85,7 @@ export * from "./layout.js";
 export * from "./line-clamp.js";
 export * from "./list.js";
 export * from "./position.js";
+export * from './semantic.js';
 export * from "./shadow.js";
 export * from "./size.js";
 export * from './space-margin.js';

--- a/src/_rules/semantic.js
+++ b/src/_rules/semantic.js
@@ -1,0 +1,7 @@
+import { handler as h } from '#utils';
+
+export const semanticRules = [
+  [/^s-bg-(.+)$/, ([, cssvar]) => ({ 'background-color': h.semanticToken(`background-${cssvar}`) })],
+  [/^s-text-(.+)$/, ([, cssvar]) => ({ color: h.semanticToken(`text-${cssvar}`) })],
+  [/^s-border-(.+)$/, ([, cssvar]) => ({ 'border-color': h.semanticToken(`border-${cssvar}`) })],
+];

--- a/src/_rules/semantic.js
+++ b/src/_rules/semantic.js
@@ -1,7 +1,10 @@
-import { handler as h } from '#utils';
+import { directionMap, handler as h } from '#utils';
 
 export const semanticRules = [
   [/^s-bg-(.+)$/, ([, cssvar]) => ({ 'background-color': h.semanticToken(`background-${cssvar}`) })],
   [/^s-text-(.+)$/, ([, cssvar]) => ({ color: h.semanticToken(`text-${cssvar}`) })],
   [/^s-border-(.+)$/, ([, cssvar]) => ({ 'border-color': h.semanticToken(`border-${cssvar}`) })],
+  [/^s-border-([lrtbxy])-(.+)$/, ([, direction, cssvar]) => directionMap[direction]?.map(
+    (dir) => [`border${dir}-color`, h.semanticToken(`border-${cssvar}`)],
+  )],
 ];

--- a/src/_utils/handlers/handlers.js
+++ b/src/_utils/handlers/handlers.js
@@ -124,6 +124,9 @@ export function bracketOfPosition(str) {
 export function warpToken(str) {
   if (str.match(/^\$\S/)) return `var(--w-${escapeSelector(str.slice(1))})`;
 }
+export function semanticToken(str) {
+  return `var(--w-s-color-${str})`;
+}
 export function cssvar(str) {
   if (str.match(/^\$\S/)) return `var(--${escapeSelector(str.slice(1))})`;
 }

--- a/test/__snapshots__/semantic.js.snap
+++ b/test/__snapshots__/semantic.js.snap
@@ -1,0 +1,16 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`it generates css based on semantic warp tokens 1`] = `
+"/* layer: default */
+.s-bg-default{background-color:var(--w-s-color-background-default);}
+.s-bg-positive-active-hover{background-color:var(--w-s-color-background-positive-active-hover);}
+.s-text-default{color:var(--w-s-color-text-default);}
+.s-text-link-active{color:var(--w-s-color-text-link-active);}
+.s-border-default{border-color:var(--w-s-color-border-default);}
+.s-border-b-negative-hover{border-bottom-color:var(--w-s-color-border-negative-hover);}
+.s-border-l-disabled{border-left-color:var(--w-s-color-border-disabled);}
+.s-border-r-primary-active-hover{border-right-color:var(--w-s-color-border-primary-active-hover);}
+.s-border-t-positive-default{border-top-color:var(--w-s-color-border-positive-default);}
+.s-border-x-warning-active{border-left-color:var(--w-s-color-border-warning-active);border-right-color:var(--w-s-color-border-warning-active);}
+.s-border-y-info-subtle-active-hover{border-top-color:var(--w-s-color-border-info-subtle-active-hover);border-bottom-color:var(--w-s-color-border-info-subtle-active-hover);}"
+`;

--- a/test/semantic.js
+++ b/test/semantic.js
@@ -1,0 +1,30 @@
+import { setup } from './_helpers.js';
+import { expect, test } from 'vitest';
+
+setup();
+
+test('it generates css based on semantic warp tokens', async ({ uno }) => {
+  const classes = [
+    's-bg-default',
+    's-bg-positive-active-hover',
+    's-text-default',
+    's-text-link-active',
+    's-border-default',
+    's-border-l-disabled',
+    's-border-r-primary-active-hover',
+    's-border-t-positive-default',
+    's-border-b-negative-hover',
+    's-border-x-warning-active',
+    's-border-y-info-subtle-active-hover',
+  ];
+  const antiClasses = [
+    's-background-default',
+    's-background-positive-active-hover',
+    's-font-default',
+    's-font-link-active',
+    's-bordercolor-default',
+    's-bordercolor-l-disabled',
+  ];
+  const { css } = await uno.generate([...classes, ...antiClasses]);
+  expect(css).toMatchSnapshot();
+});


### PR DESCRIPTION
The idea is to give consumers access to semantic variables to set background, border and text colors.

Using the class `s-bg-default` would give the following css: `background-color: var(--w-s-color-background-default);`

`s-border-positive-default` would give: `border-color: var(--w-s-color-border-positive-default);`
(also including support for directions [lrtbxy], e.g. `s-border-x-positive-default`)

and `s-text-link-hover` would give: `color: var(--w-s-color-text-link-hover);`

...based on the tokens added in this PR: https://github.com/warp-ds/tokens/pull/73