### PR TITLE
fix: escape current selector for focusable

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 dependencies:
   '@unocss/core':

--- a/src/_rules/focus-ring.js
+++ b/src/_rules/focus-ring.js
@@ -34,8 +34,9 @@ export const focusRing = [
       }
       return `.${escapedSelector}:${selectorWithVariant.split(':')?.[0]}{${focusRingStyle}}`;
     } else {
-      const focus = `.${currentSelector}:focus,.${currentSelector}:focus-visible{${focusRingStyle}}`;
-      const notFocusVisible = `.${currentSelector}:not(:focus-visible){${outlineNone}}`;
+      const escapedCurrentSelector = escapeSelector(currentSelector);
+      const focus = `.${escapedCurrentSelector}:focus,.${escapedCurrentSelector}:focus-visible{${focusRingStyle}}`;
+      const notFocusVisible = `.${escapedCurrentSelector}:not(:focus-visible){${outlineNone}}`;
       return focus + notFocusVisible;
     }
   }],


### PR DESCRIPTION
As we are on our own when we use fulle controlled rules we need to take care of the selector and escape `.`