### PR TITLE
fix: Added missing rules for static border colors 

### DIFF
--- a/src/_rules/border.js
+++ b/src/_rules/border.js
@@ -17,16 +17,16 @@ const borderStyles = [
 
 export const borders = [
   [/^border$/, handlerBorder],
+  [/^border-transparent$/, () => ({ 'border-color': 'transparent' })],
+  [/^border-inherit$/, () => ({ 'border-color': 'inherit' })],
+  [/^border-current$/, () => ({ 'border-color': 'currentColor' })],
   [/^border()-(\d+)$/, handlerBorder, { autocomplete: "(border)-<directions>" }],
-  [/^border-([xy])$/, handlerBorder],
-  [/^border-([xy])-(\d+)$/, handlerBorder],
-  [/^border-([rltb])$/, handlerBorder],
-  [/^border-([rltb])-(\d+)$/, handlerBorder],
+  [/^border-([lrtbxy])$/, handlerBorder],
+  [/^border-([lrtbxy])-(\d+)$/, handlerBorder],
   [/^border()-(.+)$/, handlerBorderStyle, { autocomplete: "(border)-style" }],
-  [/^border-([xy])-(.+)$/, handlerBorderStyle],
-  [/^border-([rltb])-(.+)$/, handlerBorderStyle],
+  [/^border-([lrtbxy])-(.+)$/, handlerBorderStyle],
   [
-    /^border-([rltb])?-?\[(\d+)\]$/,
+    /^border-([lrtb])?-?\[(\d+)\]$/,
     handlerArbitraryBorderSize,
     {
       autocomplete: [
@@ -64,6 +64,7 @@ function handlerBorderStyle([, a = "", s]) {
 export const rounded = [
   [/^rounded()(?:-(.+))?$/, handlerRounded, { autocomplete: ['(rounded)', '(rounded)-<num>'] }],
   [/^rounded-([rltb]+)(?:-(.+))?$/, handlerRounded],
+  [/^rounded([rltb]{2})(?:-(.+))?$/, handlerRounded],
   [/^rounded-([bi][se])(?:-(.+))?$/, handlerRounded],
   [/^rounded-([bi][se]-[bi][se])(?:-(.+))?$/, handlerRounded],
 ];
@@ -82,7 +83,7 @@ function handleDivideBorderSizes(direction, width, reverse, theme) {
       }
       return `border${i}-width:calc(${borderWidth} * calc(1 - var(--w-divide-${direction}-reverse)))`;
     });
-  };
+  }
 }
 
 function handlerDivideBorder([_selector, direction = "", width, reverse], { theme }) {
@@ -93,3 +94,4 @@ function handlerDivideBorder([_selector, direction = "", width, reverse], { them
     return `.${selector}>*+*{${defaultReverse};${sizes}}`;
   }
 }
+

--- a/src/_rules/border.js
+++ b/src/_rules/border.js
@@ -64,7 +64,6 @@ function handlerBorderStyle([, a = "", s]) {
 export const rounded = [
   [/^rounded()(?:-(.+))?$/, handlerRounded, { autocomplete: ['(rounded)', '(rounded)-<num>'] }],
   [/^rounded-([rltb]+)(?:-(.+))?$/, handlerRounded],
-  [/^rounded([rltb]{2})(?:-(.+))?$/, handlerRounded],
   [/^rounded-([bi][se])(?:-(.+))?$/, handlerRounded],
   [/^rounded-([bi][se]-[bi][se])(?:-(.+))?$/, handlerRounded],
 ];

--- a/test/__snapshots__/border.js.snap
+++ b/test/__snapshots__/border.js.snap
@@ -60,6 +60,13 @@ exports[`border > supports setting arbitrary border width 1`] = `
 .border-t-\\\\[7\\\\]{border-top-width:7px;}"
 `;
 
+exports[`border > supports setting border color 1`] = `
+"/* layer: default */
+.border-transparent{border-color:transparent;}
+.border-inherit{border-color:inherit;}
+.border-current{border-color:currentColor;}"
+`;
+
 exports[`border > supports setting border style 1`] = `
 "/* layer: default */
 .border-dashed{border-style:dashed;}

--- a/test/border.js
+++ b/test/border.js
@@ -50,6 +50,18 @@ describe("border", () => {
     expect(css).toMatchSnapshot();
   });
 
+  test("supports setting border color", async (t) => {
+    const classes = [
+      "border-transparent",
+      "border-inherit",
+      "border-current",
+    ];
+
+    const { css } = await t.uno.generate(classes);
+
+    expect(css).toMatchSnapshot();
+  });
+
   test("right, left, top bottom", async (t) => {
     const right = [
       "border-r",
@@ -127,3 +139,4 @@ describe("rounded", () => {
     expect(css).toMatchSnapshot();
   });
 });
+


### PR DESCRIPTION
`border-transparent|inherit|current`
(plus some minor refactoring/merging of the regex rules)