### PR TITLE
feat: add rules for outline

### DIFF
--- a/src/_rules/index.js
+++ b/src/_rules/index.js
@@ -16,6 +16,7 @@ import * as internal from './internal.js';
 import * as layout from "./layout.js";
 import * as lineClamp from "./line-clamp.js";
 import * as list from "./list.js";
+import * as outline from "./outline.js";
 import * as position from "./position.js";
 import * as semantic from './semantic.js';
 import * as shadow from "./shadow.js";
@@ -49,6 +50,7 @@ const ruleGroups = {
   ...layout,
   ...lineClamp,
   ...list,
+  ...outline,
   ...position,
   ...semantic,
   ...shadow,
@@ -84,6 +86,7 @@ export * from './internal.js';
 export * from "./layout.js";
 export * from "./line-clamp.js";
 export * from "./list.js";
+export * from "./outline.js";
 export * from "./position.js";
 export * from './semantic.js';
 export * from "./shadow.js";

--- a/src/_rules/outline.js
+++ b/src/_rules/outline.js
@@ -6,15 +6,15 @@ const outlineNone = {
 };
 
 export const outlineStyle = [
-  ["outline-none", { ... outlineNone }],
+  ["outline-none", { ...outlineNone }],
   ["outline", { "outline-style": "solid" }],
   ["outline-dashed", { "outline-style": "dashed" }],
   ["outline-dotted", { "outline-style": "dotted" }],
   ["outline-double", { "outline-style": "double" }],
 ];
 export const outlineWidth = [
-  [/^outline-(\d+)$/, ([, w]) => ({ ['outline-width']: lineWidth?.[w ?? 1] }), { autocomplete: `(outline)-(${Object.keys(lineWidth).join('|')})` }],
+  [/^outline-(\d+)$/, ([, w]) => ({ ['outline-width']: lineWidth?.[w ?? 1] }), { autocomplete: `outline-(${Object.keys(lineWidth).join('|')})` }],
 ];
 export const outlineOffset = [
-  [/^outline-offset-(\d+)$/,  ([, w]) => ({ [`outline-offset`]: lineWidth?.[w ?? 1] }), { autocomplete: `(outline-offset)-(${Object.keys(lineWidth).join('|')})` }],
+  [/^outline-offset-(\d+)$/,  ([, w]) => ({ [`outline-offset`]: lineWidth?.[w ?? 1] }), { autocomplete: `outline-offset-(${Object.keys(lineWidth).join('|')})` }],
 ];

--- a/src/_rules/outline.js
+++ b/src/_rules/outline.js
@@ -1,0 +1,20 @@
+import { lineWidth } from '#theme';
+
+const outlineNone = {
+  outline: '2px solid transparent',
+  'outline-offset': '2px',
+};
+
+export const outlineStyle = [
+  ["outline-none", { ... outlineNone }],
+  ["outline", { "outline-style": "solid" }],
+  ["outline-dashed", { "outline-style": "dashed" }],
+  ["outline-dotted", { "outline-style": "dotted" }],
+  ["outline-double", { "outline-style": "double" }],
+];
+export const outlineWidth = [
+  [/^outline-(\d+)$/, ([, w]) => ({ ['outline-width']: lineWidth?.[w ?? 1] }), { autocomplete: `(outline)-(${Object.keys(lineWidth).join('|')})` }],
+];
+export const outlineOffset = [
+  [/^outline-offset-(\d+)$/,  ([, w]) => ({ [`outline-offset`]: lineWidth?.[w ?? 1] }), { autocomplete: `(outline-offset)-(${Object.keys(lineWidth).join('|')})` }],
+];

--- a/test/__snapshots__/outline.js.snap
+++ b/test/__snapshots__/outline.js.snap
@@ -1,0 +1,28 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`outline > offset 1`] = `
+"/* layer: default */
+.outline-offset-0{outline-offset:0;}
+.outline-offset-1{outline-offset:1px;}
+.outline-offset-2{outline-offset:2px;}
+.outline-offset-4{outline-offset:4px;}
+.outline-offset-8{outline-offset:8px;}"
+`;
+
+exports[`outline > style 1`] = `
+"/* layer: default */
+.outline-none{outline:2px solid transparent;outline-offset:2px;}
+.outline{outline-style:solid;}
+.outline-dashed{outline-style:dashed;}
+.outline-dotted{outline-style:dotted;}
+.outline-double{outline-style:double;}"
+`;
+
+exports[`outline > width 1`] = `
+"/* layer: default */
+.outline-0{outline-width:0;}
+.outline-1{outline-width:1px;}
+.outline-2{outline-width:2px;}
+.outline-4{outline-width:4px;}
+.outline-8{outline-width:8px;}"
+`;

--- a/test/outline.js
+++ b/test/outline.js
@@ -1,0 +1,32 @@
+import { setup } from "./_helpers.js";
+import { describe, expect, test } from "vitest";
+import { lineWidth } from '#theme';
+
+setup();
+
+describe("outline", () => {
+  test("style", async ({ uno }) => {
+
+    const classes = [
+      "outline-none",
+      "outline",
+      "outline-dashed",
+      "outline-dotted",
+      "outline-double",
+    ];
+    const { css } = await uno.generate(classes);
+    expect(css).toMatchSnapshot();
+  });
+
+  test("width", async ({ uno }) => {
+    const classes = Object.keys(lineWidth).map(width => [`outline-${width}`]).flat();
+    const { css } = await uno.generate(classes);
+    expect(css).toMatchSnapshot();
+
+  });
+  test("offset", async ({ uno }) => {
+    const classes = Object.keys(lineWidth).map(width => [`outline-offset-${width}`]).flat();
+    const { css } = await uno.generate(classes);
+    expect(css).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
New rules for outline based on:
- https://tailwindcss.com/docs/outline-width
- https://tailwindcss.com/docs/outline-style
- https://tailwindcss.com/docs/outline-offset

With `outline-none` now added we can remove https://github.com/warp-ds/drive/blob/alpha/src/_rules/slider.js#L20. Will create a ticket for it

TBD: I'll update the css docs with this new rules