### PR TITLE
fix: proper handle bg arbitrary url as var

### DIFF
--- a/src/_rules/background.js
+++ b/src/_rules/background.js
@@ -40,7 +40,9 @@ export const backgrounds = [
   //arbitrary
   [/^bg-\[(.+)\]/, ([, p]) => {
     if (p.startsWith('url')) {
-      return { 'background-image': p };
+      // Process url(var(--something)) and extract the var itself -> --something
+      const urlAsVar = p.match(/url\(var\(([^)]*)/)?.[1];
+      return { 'background-image': urlAsVar ? `var(${urlAsVar})` : p };
     } else if (p.startsWith('var')) {
       return { 'background-color': p };
     }

--- a/test/background.js
+++ b/test/background.js
@@ -57,12 +57,14 @@ test('bg arbitrary', async ({ uno }) => {
     `bg-[url('/img/hero-pattern.svg')]`,
     `bg-[url("/img/hero-pattern.svg")]`,
     `bg-[var(--w-color)]`,
+    `before:bg-[url(var(--w-form-check-mark))]`,
     `bg-[--w-color]`,
     `peer-checked:before:bg-[url('data:image/svg+xml,%3Csvg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M4 8L7 11L12.5 5" stroke="%2371717A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/%3E%3C/svg%3E')]`,
     `bg-[url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='white'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e")]`];
   const { css } = await uno.generate(classes);
   expect(css).toMatchInlineSnapshot(`
     "/* layer: default */
+    .before\\\\:bg-\\\\[url\\\\(var\\\\(--w-form-check-mark\\\\)\\\\)\\\\]::before{background-image:var(--w-form-check-mark);}
     .bg-\\\\[--w-color\\\\],
     .bg-\\\\[var\\\\(--w-color\\\\)\\\\]{background-color:var(--w-color);}
     .bg-\\\\[url\\\\(\\\\'\\\\/img\\\\/hero-pattern\\\\.svg\\\\'\\\\)\\\\]{background-image:url('/img/hero-pattern.svg');}


### PR DESCRIPTION
[This refactoring](https://github.com/warp-ds/drive/pull/111) broke the check mark icon for the checkboxes. We needed one more check for the vars as urls.

Before|After
---|---
<img width="1365" alt="image" src="https://github.com/warp-ds/drive/assets/37986637/df04f190-8755-4ae5-b585-23b1d87ce1b2">|<img width="1499" alt="image" src="https://github.com/warp-ds/drive/assets/37986637/f3d53b1f-ea75-48c0-8637-70ba6d4c1ced">


This PR is needed to make everything work https://github.com/warp-ds/component-classes/pull/89. I tested locally, link local builds for drive and cc in vue