### PR TITLE
fix: Cleanup color classes for text and background color

### DIFF
--- a/src/_rules/color.js
+++ b/src/_rules/color.js
@@ -4,20 +4,17 @@ export const opacity = [
 
 export const caretColors = [
   ['caret-inherit', { 'caret-color': 'inherit'  }],
-  ['caret-current', { 'caret-color': 'currentColor' }],
   ['caret-transparent', { 'caret-color': 'transparent' }],
+  ['caret-current', { 'caret-color': 'currentColor' }],
 ];
 
 export const textColors = [
-  ['text', { color: 'var(--w-color-text)' }],
-  ['text-inverted', { color: 'var(--w-color-text-inverted)' }],
-  ['text-inverted-subtle', { color: 'var(--w-color-text-inverted-subtle)' }],
-  ['text-subtle', { color: 'var(--w-color-text-subtle)' }],
+//  ['text-inherit', { 'color': 'inherit' }], // This class currently sets "text-align: inherit;" in align.js
+  ['text-transparent', { 'color': 'transparent' }],
+  ['text-current', { 'color': 'currentColor' }],
 ];
 
 export const bgColors = [
-  ['bg', { 'background-color': 'var(--w-color-background)' }],
-  ['bg-subtle', { 'background-color': 'var(--w-color-background-subtle)' }],
   ['bg-inherit', { 'background-color': 'inherit' }],
   ['bg-transparent', { 'background-color': 'transparent' }],
   ['bg-current', { 'background-color': 'currentColor' }],

--- a/test/__snapshots__/color.js.snap
+++ b/test/__snapshots__/color.js.snap
@@ -2,8 +2,6 @@
 
 exports[`bg colors 1`] = `
 "/* layer: default */
-.bg{background-color:var(--w-color-background);}
-.bg-subtle{background-color:var(--w-color-background-subtle);}
 .bg-inherit{background-color:inherit;}
 .bg-transparent{background-color:transparent;}
 .bg-current{background-color:currentColor;}"
@@ -12,8 +10,8 @@ exports[`bg colors 1`] = `
 exports[`caret 1`] = `
 "/* layer: default */
 .caret-inherit{caret-color:inherit;}
-.caret-current{caret-color:currentColor;}
-.caret-transparent{caret-color:transparent;}"
+.caret-transparent{caret-color:transparent;}
+.caret-current{caret-color:currentColor;}"
 `;
 
 exports[`opacity by theme 1`] = `
@@ -27,8 +25,6 @@ exports[`opacity by theme 1`] = `
 
 exports[`text colors 1`] = `
 "/* layer: default */
-.text{color:var(--w-color-text);}
-.text-inverted{color:var(--w-color-text-inverted);}
-.text-inverted-subtle{color:var(--w-color-text-inverted-subtle);}
-.text-subtle{color:var(--w-color-text-subtle);}"
+.text-transparent{color:transparent;}
+.text-current{color:currentColor;}"
 `;

--- a/test/color.js
+++ b/test/color.js
@@ -20,7 +20,7 @@ test('opacity not created if invalid', async ({ uno }) => {
 });
 
 test('text colors', async({ uno }) => {
-  const classes = ['text' ,'text-inverted', 'text-inverted-subtle', 'text-subtle'];
+  const classes = ['text-transparent', 'text-current'];
 
   const { css } = await uno.generate(classes);
   expect(css).toMatchSnapshot();
@@ -35,8 +35,6 @@ test('text color invalid class', async({ uno }) => {
 
 test('bg colors', async({ uno }) => {
   const classes = [
-    'bg',
-    'bg-subtle',
     'bg-inherit',
     'bg-transparent',
     'bg-current'];


### PR DESCRIPTION
Removed old bg and text color classes that has been replaced with semantic equivalents and aligned text color classes with border and bg classes