### PR TITLE
fix: remove a shortcut for the outline-none

### DIFF
--- a/src/_rules/slider.js
+++ b/src/_rules/slider.js
@@ -14,15 +14,3 @@ export const sliderHandleShadow = [
     }),
   ],
 ];
-
-// Solution from Fabric for ouline styling for slider
-// TODO: Replace with outline-offset when implemented
-export const sliderOutlineNone = [
-  [
-    /^slider-handle-outline-none$/,
-    () => ({
-      outline: 'rgba(0, 0, 0, 0) solid 2px',
-      'outline-offset': '2px',
-    }),
-  ],
-];

--- a/test/__snapshots__/slider.js.snap
+++ b/test/__snapshots__/slider.js.snap
@@ -9,8 +9,3 @@ exports[`slider > get hover slider shadow 1`] = `
 "/* layer: default */
 .slider-handle-shadow-hover{box-shadow:0 0 0 6px rgba(0, 0, 0, .08);}"
 `;
-
-exports[`slider > get slider outline none 1`] = `
-"/* layer: default */
-.slider-handle-outline-none{outline:rgba(0, 0, 0, 0) solid 2px;outline-offset:2px;}"
-`;

--- a/test/slider.js
+++ b/test/slider.js
@@ -13,9 +13,4 @@ describe('slider', () => {
     const { css } = await uno.generate(['slider-handle-shadow-hover']);
     expect(css).toMatchSnapshot();
   });
-
-  test('get slider outline none', async ({ uno }) => {
-    const { css } = await uno.generate(['slider-handle-outline-none']);
-    expect(css).toMatchSnapshot();
-  });
 });


### PR DESCRIPTION
After https://github.com/warp-ds/drive/pull/125 we do not really need the custom class created only for slider.
Usage of the custom class is removed [here](https://github.com/warp-ds/component-classes/pull/94)