### PR TITLE
fix: add development flag back and externalize our published component classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ### development
 
 - `boolean`
-- Internal use only - force preflights to be excluded and no externalized classes will be processed
+- Internal use only - force preflights(resets.css + transform resets) to be excluded and no externalized classes will be processed
 
 ### usePixels
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@
 - `boolean`
 - Internal use only - force preflights(resets.css + transform resets) to be excluded and no externalized classes will be processed
 
+### omitComponentClasses
+
+- `boolean`
+- if true forces component classes to be excluded from the process. Styling for the classes already used in component classes won't be generated.
+
 ### usePixels
 
 - `boolean`

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 ## plugin API
 
-### skipPreflight
+### development
 
 - `boolean`
-- Internal use only, omits preflights from the build
+- Internal use only - force preflights to be excluded and no externalized classes will be processed
 
 ### usePixels
 

--- a/dev.js
+++ b/dev.js
@@ -23,7 +23,7 @@ const {
   },
 });
 
-const uno = createGenerator({ presets: [presetWarp( { ...options, skipPreflight: true } )] });
+const uno = createGenerator({ presets: [presetWarp( { ...options, development: true } )] });
 const devClasses = ['m-16!', 'opacity-50'];
 const classes = cliClasses ?? devClasses;
 const result = await uno.generate(classes);

--- a/package.json
+++ b/package.json
@@ -55,6 +55,9 @@
     "vite": "^4.2.0",
     "vitest": "^0.29.3"
   },
+  "peerDependencies": {
+    "@warp-ds/component-classes": "1.0.0-alpha.110"
+  },
   "eslintConfig": {
     "extends": "@warp-ds"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ dependencies:
   '@unocss/preset-mini':
     specifier: ^0.50.6
     version: 0.50.6
+  '@warp-ds/component-classes':
+    specifier: 1.0.0-alpha.110
+    version: 1.0.0-alpha.110
 
 devDependencies:
   '@rollup/plugin-node-resolve':
@@ -1078,6 +1081,10 @@ packages:
       loupe: 2.3.6
       pretty-format: 27.5.1
     dev: true
+
+  /@warp-ds/component-classes@1.0.0-alpha.110:
+    resolution: {integrity: sha512-kqOYLHBxNjyuIs7X7hlZyywxua//Gxd6+h3H13d1RT/Zfkjnr/ByUJdFvbcYqPNrNsLLwqdPsRZTbL02f0EuDg==}
+    dev: false
 
   /@warp-ds/eslint-config@0.0.1(eslint@8.36.0):
     resolution: {integrity: sha512-lzmn67NF8ZyilXDiRVPJqx95FvMGVZw//na33DDEPEnk5apeV1WD53uruFJM0DjvO9QEc51xo1zI1oS4ocWRrA==}

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,14 +1,14 @@
+import { classes } from '@warp-ds/component-classes/classes';
 import { preflights } from '#preflights';
 import { rules } from '#rules';
 import { shortcuts } from '#shortcuts';
 import { variants } from '#variants';
 import { useTheme } from '#theme';
 import { postprocess } from '#postprocess';
-
 /**
  * @typedef PluginOptions
  * @type {Object}
- * @property {boolean} skipPreflight // internal use only - force preflights to be excluded
+ * @property {boolean} development // internal use only - force preflights to be excluded and no externalized classes will be processed
  * @property {boolean} externalizeClasses - force external or 'core' classes to be included/excluded
  * @property {boolean} usePixels - use pixel spacing instead of rem
  */
@@ -16,15 +16,15 @@ import { postprocess } from '#postprocess';
 // TODO: improve generic type passed here
 /** @type {import('@unocss/core').Preset<object>} */
 export function presetWarp (options = {}) {
-  const externalizeClasses = options.externalizeClasses;
-  const externalClasses = options.externalClasses ?? []; // will possibly be our own list in the future
+  const externalizeClasses = options.externalizeClasses ?? !options.development;
+  const externalClasses = options.externalClasses ?? classes;
   const theme = useTheme(options);
   return {
     name: '@warp-ds/uno',
     theme,
     rules,
     variants,
-    preflights: options.skipPreflight ? [] : preflights,
+    preflights: options.development ? [] : preflights,
     postprocess: postprocess(externalizeClasses, externalClasses),
     shortcuts,
   };

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -8,8 +8,10 @@ import { postprocess } from '#postprocess';
 /**
  * @typedef PluginOptions
  * @type {Object}
- * @property {boolean} development // internal use only - force preflights to be excluded and no externalized classes will be processed
- * @property {boolean} externalizeClasses - force external or 'core' classes to be included/excluded
+ * @property {boolean} development // internal use only - force preflights to be excluded and no external classes will be processed
+ * @property {boolean} externalizeClasses - if true forces external or 'core' classes to be excluded from the process.
+ * @property {boolean} omitComponentClasses - if true forces component classes to be excluded from the process.
+ * @property {Array} externalClasses - list of classes that will not be processed
  * @property {boolean} usePixels - use pixel spacing instead of rem
  */
 
@@ -17,8 +19,9 @@ import { postprocess } from '#postprocess';
 /** @type {import('@unocss/core').Preset<object>} */
 export function presetWarp (options = {}) {
   checkEnvironment();
-  const externalizeClasses = options.externalizeClasses ?? !options.development;
-  const externalClasses = options.externalClasses ?? classes;
+  const externalizeClasses = options.externalizeClasses ?? !options.development; // 'true' by default
+  const safeExternalClasses = options.externalClasses || [];
+  const excludedClasses = options.omitComponentClasses ? [...classes, ...safeExternalClasses] : safeExternalClasses;
   const theme = useTheme(options);
   return {
     name: '@warp-ds/uno',
@@ -26,7 +29,7 @@ export function presetWarp (options = {}) {
     rules,
     variants,
     preflights: options.development ? [] : preflights,
-    postprocess: postprocess(externalizeClasses, externalClasses),
+    postprocess: postprocess(externalizeClasses, excludedClasses),
     shortcuts,
   };
 }

--- a/test/_helpers.js
+++ b/test/_helpers.js
@@ -2,10 +2,10 @@ import { createGenerator } from '@unocss/core';
 import { beforeEach } from 'vitest';
 import { presetWarp } from '#plugin';
 
-export const getGenerator = (opts = {}) => createGenerator({ presets: [presetWarp({ ...opts, skipPreflight: true })] });
+export const getGenerator = (opts = {}) => createGenerator({ presets: [presetWarp({ ...opts, development: true })] });
 export const setup = (opts = {}) => {
   beforeEach(t => {
-    t.uno = getGenerator({ ...opts, skipPreflight: true });
+    t.uno = getGenerator({ ...opts, development: true });
   });
 };
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,7 +4,7 @@ import { presetWarp } from '#plugin';
 
 export default defineConfig({
   plugins: [
-    UnoCSS({ presets: [presetWarp({ skipPreflight: true })] }),
+    UnoCSS({ presets: [presetWarp({ development: true })] }),
   ],
   test: {
     include: ['./test/*.js'],


### PR DESCRIPTION
As we are publishing the component.css to EIK our consumers do not need to safelist the classes anymore. They can use the css directly from EIK. Benefits: cached css instead of every app safelists the classes. Could be added to the template etc

And as we don't want duplicated styles to be generated we can finally use `externalizedClasses` and postprocess feature. For that I needed a flag and I took back `development` flag that we removed when we thought that preflight was the only feature that that flag controlled.


When this one is merged we will need to update https://github.com/warp-ds/playground/blob/b1584b611bc0cdb9b98cb10a576bc49bb4105f11/src/css.js#L9 and use the `development` flag instead