### PR TITLE
feat: arbitrary values accepted for leading

### DIFF
--- a/src/_rules/size.js
+++ b/src/_rules/size.js
@@ -1,15 +1,7 @@
-import { handler as h, resolveBreakpoints, resolveVerticalBreakpoints } from '#utils';
+import { handler as h, resolveBreakpoints, resolveVerticalBreakpoints, resolveArbitraryValues } from '#utils';
 
 const sizeMapping = { h: 'height', w: 'width' };
 const getPropName = (minmax, hw) => `${minmax || ''}${sizeMapping[hw]}`;
-const resolveArbitraryValues = (value, unit, context) => {
-  if (unit === "rem") return h.rem(`${value}${unit}`);
-  if (unit === "px" || context.theme.usingPixels) return h.px(value);
-  if (value.startsWith('--')) {
-    return `var(${value})`;
-  }
-  return h.rem(value) || value;
-};
 
 function getSizeValue(minmax, hw, theme, prop) {
   const str = getPropName(minmax, hw).replace(/-(\w)/g, (_, p) => p.toUpperCase());

--- a/src/_rules/typography.js
+++ b/src/_rules/typography.js
@@ -1,4 +1,4 @@
-import { textMap, lineHeightMap } from '#utils';
+import { textMap, lineHeightMap, resolveArbitraryValues } from '#utils';
 
 export const typography = [
   [/^text-(12|14|16|20|22|28|34|48)$/, ([, d]) => ({ 'font-size': `var(--w-font-size-${textMap[d]})`, 'line-height': `var(--w-line-height-${textMap[d]})` })],
@@ -9,4 +9,5 @@ export const typography = [
   [/^leading-(xs|s|m|ml|l|xl|xxl|xxxl)$/, ([, size]) =>
     ({ 'line-height': `var(--w-line-height-${size})` }),
   ],
+  [/^leading-\[(.+)(rem|px)?\]/, ([, value, unit], context) => ({ 'line-height': resolveArbitraryValues(value, unit, context) })],
 ];

--- a/src/_utils/utilities.js
+++ b/src/_utils/utilities.js
@@ -218,3 +218,12 @@ export function getBracket(str, open, close) {
     }
   }
 }
+
+export function resolveArbitraryValues(value, unit, context) {
+  if (unit === "rem") return h.rem(`${value}${unit}`);
+  if (unit === "px" || context.theme.usingPixels) return h.px(value);
+  if (value.startsWith('--')) {
+    return `var(${value})`;
+  }
+  return h.rem(value) || value;
+};

--- a/test/__snapshots__/typography.js.snap
+++ b/test/__snapshots__/typography.js.snap
@@ -40,6 +40,14 @@ exports[`typography - leading classes  1`] = `
 .leading-xxxl{line-height:var(--w-line-height-xxxl);}"
 `;
 
+exports[`typography - leading classes with arbitrary values 1`] = `
+"/* layer: default */
+.leading-\\\\[11\\\\]{line-height:1.1rem;}
+.leading-\\\\[24\\\\]{line-height:2.4rem;}
+.leading-\\\\[24px\\\\]{line-height:24px;}
+.leading-\\\\[24rem\\\\]{line-height:24rem;}"
+`;
+
 exports[`typography - text classes  1`] = `
 "/* layer: default */
 .text-12,

--- a/test/typography.js
+++ b/test/typography.js
@@ -17,6 +17,12 @@ test('typography - leading classes ', async ({ uno }) => {
   expect(css).toMatchSnapshot();
 });
 
+test('typography - leading classes with arbitrary values', async ({ uno }) => {
+  const classes = [`leading-[24]`, `leading-[11]`, `leading-[24px]`, `leading-[24rem]`].flat();
+  const { css } = await uno.generate(classes);
+  expect(css).toMatchSnapshot();
+});
+
 test('shortcuts', async ({ uno }) => {
   const classes = Object.keys(typographyAliases);
   const { css } = await uno.generate(classes);


### PR DESCRIPTION
Almost all buttons are using `leading-24` . The class is also used in one place in finn. 24 - is not a part of our tokens so we need to support arbitrary values here. (more info about the discussion [here](https://sch-chat.slack.com/archives/C050N3NQ204/p1686921532451109))

We have also one usage of the custom line-height https://github.com/fabric-ds/css/blob/49b07c05686ef132b203026e941bf04dbab6fc7a/src/components/form-elements.css#L176 that we will be able to set with this support.