### PR TITLE
fix: cache the preflight instead of requesting every rebuild

### DIFF
--- a/src/_preflights/resets.js
+++ b/src/_preflights/resets.js
@@ -1,4 +1,6 @@
+const reset = (await fetch('https://assets.finn.no/pkg/@warp-ds/css/v1/resets.min.css')).text();
+
 export const resets = {
   layer: 'preflights',
-  getCSS: async () => (await fetch('https://assets.finn.no/pkg/@warp-ds/css/v1/resets.min.css')).text(),
+  getCSS: () => reset,
 };


### PR DESCRIPTION
The `getCSS` function runs every time the plugin is doing a build - which when developing locally is _often_.

Caching the CSS here means our servers will serve less data, and also the local development experience will be sped up by however long this download would have taken; meaning if this download would ever experience issues the user's dev-env would hang for unknown reasons to them!