### PR TITLE
fix: add missing classes Fabric supported

### DIFF
--- a/src/_rules/border.js
+++ b/src/_rules/border.js
@@ -18,7 +18,7 @@ const borderStyles = [
 export const borders = [
   [/^border$/, handlerBorder],
   [/^border-transparent$/, () => ({ 'border-color': 'transparent' })],
-  [/^border-white$/, () => ({ 'border-color': 'var(--w-white)' })],
+  [/^border-inverted$/, () => ({ 'border-color': 'var(--w-s-border-inverted)' })],
   [/^border-inherit$/, () => ({ 'border-color': 'inherit' })],
   [/^border-current$/, () => ({ 'border-color': 'currentColor' })],
   [/^border()-(\d+)$/, handlerBorder, { autocomplete: "(border)-<directions>" }],

--- a/src/_rules/border.js
+++ b/src/_rules/border.js
@@ -18,6 +18,7 @@ const borderStyles = [
 export const borders = [
   [/^border$/, handlerBorder],
   [/^border-transparent$/, () => ({ 'border-color': 'transparent' })],
+  [/^border-white$/, () => ({ 'border-color': 'var(--w-white)' })],
   [/^border-inherit$/, () => ({ 'border-color': 'inherit' })],
   [/^border-current$/, () => ({ 'border-color': 'currentColor' })],
   [/^border()-(\d+)$/, handlerBorder, { autocomplete: "(border)-<directions>" }],

--- a/src/_rules/typography.js
+++ b/src/_rules/typography.js
@@ -11,4 +11,5 @@ export const typography = [
   ],
   [/^leading-\[(.+)(rem|px)?\]/, ([, value, unit], context) => ({ 'line-height': resolveArbitraryValues(value, unit, context) })],
   ['tabular-nums', { 'font-family': 'ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif', 'font-variant-numeric': 'tabular-nums' }],
+  ['lining-nums', { 'font-variant-numeric': 'lining-nums' }],
 ];

--- a/src/_rules/typography.js
+++ b/src/_rules/typography.js
@@ -10,4 +10,5 @@ export const typography = [
     ({ 'line-height': `var(--w-line-height-${size})` }),
   ],
   [/^leading-\[(.+)(rem|px)?\]/, ([, value, unit], context) => ({ 'line-height': resolveArbitraryValues(value, unit, context) })],
+  ['tabular-nums', { 'font-family': 'ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif', 'font-variant-numeric': 'tabular-nums' }],
 ];

--- a/src/_rules/typography.js
+++ b/src/_rules/typography.js
@@ -12,4 +12,8 @@ export const typography = [
   [/^leading-\[(.+)(rem|px)?\]/, ([, value, unit], context) => ({ 'line-height': resolveArbitraryValues(value, unit, context) })],
   ['tabular-nums', { 'font-family': 'ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif', 'font-variant-numeric': 'tabular-nums' }],
   ['lining-nums', { 'font-variant-numeric': 'lining-nums' }],
+  ['ordinal', { 'font-variant-numeric': 'ordinal' }],
+  ['slashed-zero', { 'font-variant-numeric': 'slashed-zero' }],
+  ['oldstyle-nums', { 'font-variant-numeric': 'oldstyle-nums' }],
+  ['proportional-nums', { 'font-variant-numeric': 'proportional-nums' }],
 ];


### PR DESCRIPTION
[WARP-121](https://nmp-jira.atlassian.net/browse/WARP-121): Add `tabular-nums`, `lining-nums` and `border-inverted` (to replace `border-white` ) + some font variant numeric classes from tailwind.

Other notes: 
* PR to update parity with these findings: https://github.com/warp-ds/parity/pull/3
* New working document to investigate the classes: https://docs.google.com/spreadsheets/d/1W0n74LSV6IG2YIU1LJNopFNtTkSYLY3rfPa9c1qg9d4/edit#gid=0
* We also had this from earlier: https://docs.google.com/spreadsheets/d/1gk1LhpUimjk9QnZhZyId7c56xk30dbzQxRCzuGLlllY/edit#gid=0

