### PR TITLE
fix: check for type string before matching the class in the last-child transformation

### DIFF
--- a/src/_variants/lastChild.js
+++ b/src/_variants/lastChild.js
@@ -1,4 +1,5 @@
 export const variantLastChild = (matcher) => {
+  if (typeof matcher !== 'string') return;
   if (!matcher?.startsWith('last-child:')) { return matcher; };
   return {
     matcher: matcher.slice(11),


### PR DESCRIPTION
Background: https://sch-chat.slack.com/archives/C04P0GYTHPV/p1688042140581689

I've tested locally by adding shortcuts as safelist 😈 