### PR TITLE
fix: avoid top-level await in reset

### DIFF
--- a/src/_preflights/resets.js
+++ b/src/_preflights/resets.js
@@ -1,6 +1,13 @@
-const reset = (await fetch('https://assets.finn.no/pkg/@warp-ds/css/v1/resets.min.css')).text();
+let reset;
+async function getReset() {
+  if (reset) return reset;
+  else {
+    reset = (await fetch('https://assets.finn.no/pkg/@warp-ds/css/v1/resets.min.css')).text();
+    return reset;
+  }
+}
 
 export const resets = {
   layer: 'preflights',
-  getCSS: () => reset,
+  getCSS: getReset,
 };


### PR DESCRIPTION
Top-level await was causing issues when used client-side (e.g. the playground)