### PR TITLE
fix: Update focus outline to use new semantic color token

### DIFF
--- a/src/_rules/focus-ring.js
+++ b/src/_rules/focus-ring.js
@@ -2,7 +2,7 @@ import { entriesToCss, escapeSelector } from '@unocss/core';
 
 // TODO: use actual variables and values when those has been defined
 const focusRingStyle = entriesToCss(Object.entries({
-  outline: '2px solid var(--w-color-focused)',
+  outline: '2px solid var(--w-s-color-focused)',
   'outline-offset': 'var(--w-outline-offset, 1px)',
 }));
 

--- a/test/focus-ring.js
+++ b/test/focus-ring.js
@@ -16,10 +16,10 @@ test("focus ring", async (t) => {
 
   expect(css).toMatchInlineSnapshot(`
     "/* layer: default */
-    .focus-within\\\\:focusable:focus-within{outline:2px solid var(--w-color-focused);outline-offset:var(--w-outline-offset, 1px);}
-    .focusable:focus,.focusable:focus-visible{outline:2px solid var(--w-color-focused);outline-offset:var(--w-outline-offset, 1px);}.focusable:not(:focus-visible){outline:none;}
-    .group:focus .group-focus\\\\:focusable,.group:focus-visible .group-focus\\\\:focusable{outline:2px solid var(--w-color-focused);outline-offset:var(--w-outline-offset, 1px);}.group:not(:focus-visible) .group-focus\\\\:focusable{outline:none;}
-    .peer:focus~.peer-focus\\\\:focusable,.peer:focus-visible~.peer-focus\\\\:focusable{outline:2px solid var(--w-color-focused);outline-offset:var(--w-outline-offset, 1px);}.peer:not(:focus-visible)~.peer-focus\\\\:focusable{outline:none;}
+    .focus-within\\\\:focusable:focus-within{outline:2px solid var(--w-s-color-focused);outline-offset:var(--w-outline-offset, 1px);}
+    .focusable:focus,.focusable:focus-visible{outline:2px solid var(--w-s-color-focused);outline-offset:var(--w-outline-offset, 1px);}.focusable:not(:focus-visible){outline:none;}
+    .group:focus .group-focus\\\\:focusable,.group:focus-visible .group-focus\\\\:focusable{outline:2px solid var(--w-s-color-focused);outline-offset:var(--w-outline-offset, 1px);}.group:not(:focus-visible) .group-focus\\\\:focusable{outline:none;}
+    .peer:focus~.peer-focus\\\\:focusable,.peer:focus-visible~.peer-focus\\\\:focusable{outline:2px solid var(--w-s-color-focused);outline-offset:var(--w-outline-offset, 1px);}.peer:not(:focus-visible)~.peer-focus\\\\:focusable{outline:none;}
     .focusable-inset{--w-outline-offset:-3px;}"
   `);
 });


### PR DESCRIPTION
Needs added token from: https://github.com/warp-ds/css/pull/19