### PR TITLE
fix: Remove old fallback values from box shadows

### DIFF
--- a/src/_rules/shadow.js
+++ b/src/_rules/shadow.js
@@ -1,16 +1,5 @@
-// TODO: Handle dynamic rgba colors instead of constant colors
-
-const defaultColor = 'rgba(0, 0, 0, .2)';
-
-const boxShadowDefaults = {
-  s: `0 1px 6px ${defaultColor}, 0 1px 1px ${defaultColor}`,
-  m: `0 3px 8px ${defaultColor}, 0 3px 6px ${defaultColor}`,
-  l: `0 6px 8px ${defaultColor}, 0 10px 20px ${defaultColor}`,
-  xl: `0 9px 12px ${defaultColor}, 0 14px 28px ${defaultColor}`,
-};
-
 export const shadows = [
-  [/^shadow-(s|m|l|xl)$/, ([, size]) => ({ 'box-shadow': `var(--w-shadow-${size}, ${boxShadowDefaults[size]})` })],
+  [/^shadow-(s|m|l|xl)$/, ([, size]) => ({ 'box-shadow': `var(--w-shadow-${size})` })],
 ];
 
 const dropShadowDefaultColor = '64, 64, 64';

--- a/test/__snapshots__/shadow.js.snap
+++ b/test/__snapshots__/shadow.js.snap
@@ -10,8 +10,8 @@ exports[`drop shadows 1`] = `
 
 exports[`shadows work 1`] = `
 "/* layer: default */
-.shadow-l{box-shadow:var(--w-shadow-l, 0 6px 8px rgba(0, 0, 0, .2), 0 10px 20px rgba(0, 0, 0, .2));}
-.shadow-m{box-shadow:var(--w-shadow-m, 0 3px 8px rgba(0, 0, 0, .2), 0 3px 6px rgba(0, 0, 0, .2));}
-.shadow-s{box-shadow:var(--w-shadow-s, 0 1px 6px rgba(0, 0, 0, .2), 0 1px 1px rgba(0, 0, 0, .2));}
-.shadow-xl{box-shadow:var(--w-shadow-xl, 0 9px 12px rgba(0, 0, 0, .2), 0 14px 28px rgba(0, 0, 0, .2));}"
+.shadow-l{box-shadow:var(--w-shadow-l);}
+.shadow-m{box-shadow:var(--w-shadow-m);}
+.shadow-s{box-shadow:var(--w-shadow-s);}
+.shadow-xl{box-shadow:var(--w-shadow-xl);}"
 `;


### PR DESCRIPTION
Removing old hard coded fallback values for box-shadows as discussed here: https://sch-chat.slack.com/archives/C050N3NQ204/p1688047940344899