### PR TITLE
fix: use new css repo for component classes

### DIFF
--- a/dev.js
+++ b/dev.js
@@ -12,12 +12,18 @@ const {
       short: 'c',
     },
     externalClasses: {
-      type: 'boolean',
+      type: 'string',
     },
     externalizeClasses: {
       type: 'boolean',
     },
     usePixels: {
+      type: 'boolean',
+    },
+    omitComponentClasses: {
+      type: 'boolean',
+    },
+    skipResets: {
       type: 'boolean',
     },
   },

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "vitest": "^0.29.3"
   },
   "peerDependencies": {
-    "@warp-ds/component-classes": "1.0.0-alpha.110"
+    "@warp-ds/css": "^1.0.0-alpha.29"
   },
   "eslintConfig": {
     "extends": "@warp-ds"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "vitest": "^0.29.3"
   },
   "peerDependencies": {
-    "@warp-ds/css": "^1.0.0-alpha.29"
+    "@warp-ds/css": "^1.0.0-alpha.33"
   },
   "eslintConfig": {
     "extends": "@warp-ds"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -11,9 +11,9 @@ dependencies:
   '@unocss/preset-mini':
     specifier: ^0.50.6
     version: 0.50.6
-  '@warp-ds/component-classes':
-    specifier: 1.0.0-alpha.110
-    version: 1.0.0-alpha.110
+  '@warp-ds/css':
+    specifier: ^1.0.0-alpha.29
+    version: 1.0.0-alpha.29(@warp-ds/component-classes@1.0.0-alpha.110)
 
 devDependencies:
   '@rollup/plugin-node-resolve':
@@ -1086,6 +1086,16 @@ packages:
     resolution: {integrity: sha512-kqOYLHBxNjyuIs7X7hlZyywxua//Gxd6+h3H13d1RT/Zfkjnr/ByUJdFvbcYqPNrNsLLwqdPsRZTbL02f0EuDg==}
     dev: false
 
+  /@warp-ds/css@1.0.0-alpha.29(@warp-ds/component-classes@1.0.0-alpha.110):
+    resolution: {integrity: sha512-7CsQebbTlDjOGvl8Ewf9BAQ/DULCcA2d7Q2lVBdEXly4OoIvus26RhS3RqWQtfkT0cQHR02L34j+B5LBwsGDAA==}
+    dependencies:
+      '@warp-ds/fonts': 1.1.0
+      '@warp-ds/tokenizer': 0.0.2
+      '@warp-ds/uno': 1.0.0-alpha.57(@warp-ds/component-classes@1.0.0-alpha.110)
+    transitivePeerDependencies:
+      - '@warp-ds/component-classes'
+    dev: false
+
   /@warp-ds/eslint-config@0.0.1(eslint@8.36.0):
     resolution: {integrity: sha512-lzmn67NF8ZyilXDiRVPJqx95FvMGVZw//na33DDEPEnk5apeV1WD53uruFJM0DjvO9QEc51xo1zI1oS4ocWRrA==}
     peerDependencies:
@@ -1093,6 +1103,27 @@ packages:
     dependencies:
       eslint: 8.36.0
     dev: true
+
+  /@warp-ds/fonts@1.1.0:
+    resolution: {integrity: sha512-kLNZzK3o0rMJApm7/YT3K7rYoFKgH5PyJMTVwv34O4Dx6ikfN7appc4f2DFYkE2XY6gifpD5F2r1ftcJtdW4+w==}
+    dev: false
+
+  /@warp-ds/tokenizer@0.0.2:
+    resolution: {integrity: sha512-pEtBvP6my14f1kOmYSoDNhofGK/L2yNqnZkEotvY6boVs3jcIncHpgo9Nt4AHOiAvzDrPP0t8b36jwqGaWzNPg==}
+    dependencies:
+      glob: 9.3.5
+      yaml: 2.3.1
+    dev: false
+
+  /@warp-ds/uno@1.0.0-alpha.57(@warp-ds/component-classes@1.0.0-alpha.110):
+    resolution: {integrity: sha512-DPV+0uzb0DWRmY1YM3CkkR5HSemZG8gW+r8NEAycbraMY9dSESg7pcOEQREKdAAye3HfwhDjD7Dh69LjsP7JsA==}
+    peerDependencies:
+      '@warp-ds/component-classes': 1.0.0-alpha.110
+    dependencies:
+      '@unocss/core': 0.50.6
+      '@unocss/preset-mini': 0.50.6
+      '@warp-ds/component-classes': 1.0.0-alpha.110
+    dev: false
 
   /JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
@@ -1263,7 +1294,6 @@ packages:
 
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-    dev: true
 
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -1296,6 +1326,12 @@ packages:
       balanced-match: 1.0.2
       concat-map: 0.0.1
     dev: true
+
+  /brace-expansion@2.0.1:
+    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+    dependencies:
+      balanced-match: 1.0.2
+    dev: false
 
   /braces@3.0.2:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
@@ -2214,7 +2250,6 @@ packages:
 
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-    dev: true
 
   /fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -2277,6 +2312,16 @@ packages:
       once: 1.4.0
       path-is-absolute: 1.0.1
     dev: true
+
+  /glob@9.3.5:
+    resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      fs.realpath: 1.0.0
+      minimatch: 8.0.4
+      minipass: 4.2.8
+      path-scurry: 1.10.0
+    dev: false
 
   /global-dirs@0.1.1:
     resolution: {integrity: sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg==}
@@ -2875,6 +2920,11 @@ packages:
       get-func-name: 2.0.0
     dev: true
 
+  /lru-cache@10.0.0:
+    resolution: {integrity: sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw==}
+    engines: {node: 14 || >=16.14}
+    dev: false
+
   /lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
@@ -3004,6 +3054,13 @@ packages:
       brace-expansion: 1.1.11
     dev: true
 
+  /minimatch@8.0.4:
+    resolution: {integrity: sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: false
+
   /minimist-options@4.1.0:
     resolution: {integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==}
     engines: {node: '>= 6'}
@@ -3020,6 +3077,16 @@ packages:
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
     dev: true
+
+  /minipass@4.2.8:
+    resolution: {integrity: sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /minipass@6.0.2:
+    resolution: {integrity: sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dev: false
 
   /mlly@1.2.0:
     resolution: {integrity: sha512-+c7A3CV0KGdKcylsI6khWyts/CYrGTrRVo4R/I7u/cUsy0Conxa6LUhiEzVKIw14lc2L5aiO4+SeVe4TeGRKww==}
@@ -3452,6 +3519,14 @@ packages:
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
     dev: true
+
+  /path-scurry@1.10.0:
+    resolution: {integrity: sha512-tZFEaRQbMLjwrsmidsGJ6wDMv0iazJWk6SfIKnY4Xru8auXgmJkOBa5DUbYFcFD2Rzk2+KDlIiF0GVXNCbgC7g==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      lru-cache: 10.0.0
+      minipass: 6.0.2
+    dev: false
 
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -4578,6 +4653,11 @@ packages:
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
     dev: true
+
+  /yaml@2.3.1:
+    resolution: {integrity: sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==}
+    engines: {node: '>= 14'}
+    dev: false
 
   /yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^0.50.6
     version: 0.50.6
   '@warp-ds/css':
-    specifier: ^1.0.0-alpha.29
-    version: 1.0.0-alpha.29(@warp-ds/component-classes@1.0.0-alpha.110)
+    specifier: ^1.0.0-alpha.33
+    version: 1.0.0-alpha.33(@warp-ds/component-classes@1.0.0-alpha.110)
 
 devDependencies:
   '@rollup/plugin-node-resolve':
@@ -1086,8 +1086,8 @@ packages:
     resolution: {integrity: sha512-kqOYLHBxNjyuIs7X7hlZyywxua//Gxd6+h3H13d1RT/Zfkjnr/ByUJdFvbcYqPNrNsLLwqdPsRZTbL02f0EuDg==}
     dev: false
 
-  /@warp-ds/css@1.0.0-alpha.29(@warp-ds/component-classes@1.0.0-alpha.110):
-    resolution: {integrity: sha512-7CsQebbTlDjOGvl8Ewf9BAQ/DULCcA2d7Q2lVBdEXly4OoIvus26RhS3RqWQtfkT0cQHR02L34j+B5LBwsGDAA==}
+  /@warp-ds/css@1.0.0-alpha.33(@warp-ds/component-classes@1.0.0-alpha.110):
+    resolution: {integrity: sha512-zc+g1CyKptApAfryLKpEc5N3SnPW87gl7Rx2Zz9hGOrqY42PvjG2NplkKbas1/bLvpGKW5VTBrdaVcyt049cFA==}
     dependencies:
       '@warp-ds/fonts': 1.1.0
       '@warp-ds/tokenizer': 0.0.2

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,4 +1,4 @@
-import { classes } from '@warp-ds/component-classes/classes';
+import { classes } from '@warp-ds/css/component-classes/classes';
 import { preflights } from '#preflights';
 import { rules } from '#rules';
 import { shortcuts } from '#shortcuts';


### PR DESCRIPTION
Now that we have own new css repo which contains component-classes we need to update dependencies and imports

- [x] bump to the latest version of the css before merge
