### PR TITLE
fix: avoid null issue and use empty array instead

### DIFF
--- a/src/postprocessor.js
+++ b/src/postprocessor.js
@@ -6,7 +6,7 @@ const classify = (str) => `.${escapeSelector(str)}`;
 export const postprocess = (shouldExternalize, _externalClasses = []) => {
   const externalClasses = _externalClasses.map(classify);
   return (obj) => {
-    if (shouldExternalize && externalClasses.includes(obj.selector)) return obj.entries = null;
+    if (shouldExternalize && externalClasses.includes(obj.selector)) return obj.entries = [];
     obj.entries.forEach(e => {
       e[0] = e[0].replace(/^--un-/, `--${prefix}`);
       if (typeof e[1] === "string") e[1] = e[1].replace(/var\(--un-/g, `var(--${prefix}`);


### PR DESCRIPTION
**Background:**
We want to omit component classes from drive if we are including the component.css from eik instead. This can be done by using the`omitComponentClasses: true` flag in `uno.config`.  However, when using this flag, we got this error in the project using drive: 

```
node_modules/.pnpm/@unocss+core@0.53.1/node_modules/@unocss/core/dist/index.mjs:958
        ...stringify(false, noMerge, e3.filter(([entries]) => entries.some((entry) => entry[0] === CONTROL_SHORTCUT_NO_MERGE))),
        
TypeError: Cannot read properties of null (reading 'some')
```

**Solution:**
Do not set entries to be `null` use an empty array instead. Not sure if this will have side effects... 

