### PR TITLE
fix(display.js): align order of css for display classes with fabric.css

### DIFF
--- a/src/_rules/display.js
+++ b/src/_rules/display.js
@@ -2,19 +2,13 @@ import { globalKeywords, handler as h } from '#utils';
 
 
 export const display = [
-  ['flex', { display: 'flex' }],
-  ['inline-flex', { display: 'inline-flex' }],
-  ['grid', { display: 'grid' }],
-  ['inline-grid', { display: 'inline-grid' }],
-  ['inline', { display: 'inline' }],
   ['block', { display: 'block' }],
   ['inline-block', { display: 'inline-block' }],
-  ['contents', { display: 'contents' }],
-  ['flow-root', { display: 'flow-root' }],
-  ['list-item', { display: 'list-item' }],
-  ['hidden', { display: 'none' }],
-  ['inline-table', { display: 'inline-table' }],
+  ['inline', { display: 'inline' }],
+  ['flex', { display: 'flex' }],
+  ['inline-flex', { display: 'inline-flex' }],
   ['table', { display: 'table' }],
+  ['inline-table', { display: 'inline-table' }],
   ['table-caption', { display: 'table-caption' }],
   ['table-cell', { display: 'table-cell' }],
   ['table-column', { display: 'table-column' }],
@@ -23,6 +17,12 @@ export const display = [
   ['table-header-group', { display: 'table-header-group' }],
   ['table-row', { display: 'table-row' }],
   ['table-row-group', { display: 'table-row-group' }],
+  ['flow-root', { display: 'flow-root' }],
+  ['grid', { display: 'grid' }],
+  ['inline-grid', { display: 'inline-grid' }],
+  ['contents', { display: 'contents' }],
+  ['list-item', { display: 'list-item' }],
+  ['hidden', { display: 'none' }],
   // unset, revert, inherit
   [/^display-(.+)$/, ([, c]) => ({ display: h.cssvar.global(c) }), { autocomplete: `display-${globalKeywords.join('|')}` }],
 ];

--- a/test/__snapshots__/display.js.snap
+++ b/test/__snapshots__/display.js.snap
@@ -11,19 +11,13 @@ exports[`display > should render styles for arbitrary values 1`] = `
 
 exports[`display > should render styles for static classes 1`] = `
 "/* layer: default */
-.flex{display:flex;}
-.inline-flex{display:inline-flex;}
-.grid{display:grid;}
-.inline-grid{display:inline-grid;}
-.inline{display:inline;}
 .block{display:block;}
 .inline-block{display:inline-block;}
-.contents{display:contents;}
-.flow-root{display:flow-root;}
-.list-item{display:list-item;}
-.hidden{display:none;}
-.inline-table{display:inline-table;}
+.inline{display:inline;}
+.flex{display:flex;}
+.inline-flex{display:inline-flex;}
 .table{display:table;}
+.inline-table{display:inline-table;}
 .table-caption{display:table-caption;}
 .table-cell{display:table-cell;}
 .table-column{display:table-column;}
@@ -31,5 +25,11 @@ exports[`display > should render styles for static classes 1`] = `
 .table-footer-group{display:table-footer-group;}
 .table-header-group{display:table-header-group;}
 .table-row{display:table-row;}
-.table-row-group{display:table-row-group;}"
+.table-row-group{display:table-row-group;}
+.flow-root{display:flow-root;}
+.grid{display:grid;}
+.inline-grid{display:inline-grid;}
+.contents{display:contents;}
+.list-item{display:list-item;}
+.hidden{display:none;}"
 `;


### PR DESCRIPTION
The order of CSS for display classes is now aligned with [fabric.css](https://assets.finn.no/pkg/@fabric-ds/css/1.2.0/fabric.min.css) that Warp should be based on. This fixes e.g. issues with `flex` class not overriding any other default display style of a given element, like it used to in Fabric.