### PR TITLE
fix: remove @warp-ds/css dep to fix circular dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,6 @@
 - `boolean`
 - If true forces resets to be excluded from preflights
 
-### omitComponentClasses
-
-- `boolean`
-- if true forces component classes to be excluded from the process. Styling for the classes already used in component classes won't be generated.
-
 ### usePixels
 
 - `boolean`

--- a/dev.js
+++ b/dev.js
@@ -20,9 +20,6 @@ const {
     usePixels: {
       type: 'boolean',
     },
-    omitComponentClasses: {
-      type: 'boolean',
-    },
     skipResets: {
       type: 'boolean',
     },

--- a/package.json
+++ b/package.json
@@ -55,9 +55,6 @@
     "vite": "^4.2.0",
     "vitest": "^0.29.3"
   },
-  "peerDependencies": {
-    "@warp-ds/css": "^1.0.0-alpha.37"
-  },
   "eslintConfig": {
     "extends": "@warp-ds"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ dependencies:
   '@unocss/preset-mini':
     specifier: ^0.52.7
     version: 0.52.7
-  '@warp-ds/css':
-    specifier: ^1.0.0-alpha.37
-    version: 1.0.0-alpha.37
 
 devDependencies:
   '@rollup/plugin-node-resolve':
@@ -924,10 +921,6 @@ packages:
       unconfig: 0.3.10
     dev: true
 
-  /@unocss/core@0.50.8:
-    resolution: {integrity: sha512-rWmyeNE0Na8dJPDynLVar0X22qMHFNhO+/F2FZDpG4tubTavXJJo9uvhZr/D381kiWxt+XZ38y6EAD4UMdBqMA==}
-    dev: false
-
   /@unocss/core@0.52.7:
     resolution: {integrity: sha512-dZonrlfu33SkUMsZXlsyYSM79tr2nLer/hBEU2ZaemRik2KchxIUNlZV6kX1f1k3m+gEtVQOyx1MImpgLS8PWg==}
     dev: false
@@ -983,12 +976,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-  /@unocss/preset-mini@0.50.8:
-    resolution: {integrity: sha512-/4sbOdyaqJMvFkw1xzo2+h6bZJHw6WCYw1mF+f0ydHzj8ruvwaj9ClDDOweW5cdrk3wzDzRZ6NPRahKqLwv6/Q==}
-    dependencies:
-      '@unocss/core': 0.50.8
-    dev: false
 
   /@unocss/preset-mini@0.52.7:
     resolution: {integrity: sha512-c5VRzPwyAmIBWwz2ufEboYwHGiheG+V9SCmJJLHlu/gcW5KndFsxoeJPE6nOfXVmbx4AGq/rkzV35ZXtH8Iecw==}
@@ -1129,14 +1116,6 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
-  /@warp-ds/css@1.0.0-alpha.37:
-    resolution: {integrity: sha512-kBJ6zytvgaIH0GSDMg2IC8VYMtCDoCN/TxxtdQyh4wq+VPe95+5hz+asqUSnJuMUUuIj1jsrPkQb2bfCCcTUdg==}
-    dependencies:
-      '@warp-ds/fonts': 1.1.0
-      '@warp-ds/tokenizer': 0.0.2
-      '@warp-ds/uno': 1.0.0-alpha.62(@warp-ds/css@1.0.0-alpha.37)
-    dev: false
-
   /@warp-ds/eslint-config@0.0.1(eslint@8.36.0):
     resolution: {integrity: sha512-lzmn67NF8ZyilXDiRVPJqx95FvMGVZw//na33DDEPEnk5apeV1WD53uruFJM0DjvO9QEc51xo1zI1oS4ocWRrA==}
     peerDependencies:
@@ -1144,27 +1123,6 @@ packages:
     dependencies:
       eslint: 8.36.0
     dev: true
-
-  /@warp-ds/fonts@1.1.0:
-    resolution: {integrity: sha512-kLNZzK3o0rMJApm7/YT3K7rYoFKgH5PyJMTVwv34O4Dx6ikfN7appc4f2DFYkE2XY6gifpD5F2r1ftcJtdW4+w==}
-    dev: false
-
-  /@warp-ds/tokenizer@0.0.2:
-    resolution: {integrity: sha512-pEtBvP6my14f1kOmYSoDNhofGK/L2yNqnZkEotvY6boVs3jcIncHpgo9Nt4AHOiAvzDrPP0t8b36jwqGaWzNPg==}
-    dependencies:
-      glob: 9.3.5
-      yaml: 2.3.1
-    dev: false
-
-  /@warp-ds/uno@1.0.0-alpha.62(@warp-ds/css@1.0.0-alpha.37):
-    resolution: {integrity: sha512-BVejIJ/Yd4nLRhj/n4z44FRXpxE9efXxa+G4En1iWL1n4hwMkWiIIOPxaf9pUgYzGXz4KrBFYfwFvniTcvkgow==}
-    peerDependencies:
-      '@warp-ds/css': ^1.0.0-alpha.33
-    dependencies:
-      '@unocss/core': 0.50.8
-      '@unocss/preset-mini': 0.50.8
-      '@warp-ds/css': 1.0.0-alpha.37
-    dev: false
 
   /JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
@@ -1337,6 +1295,7 @@ packages:
 
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+    dev: true
 
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -1369,12 +1328,6 @@ packages:
       balanced-match: 1.0.2
       concat-map: 0.0.1
     dev: true
-
-  /brace-expansion@2.0.1:
-    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
-    dependencies:
-      balanced-match: 1.0.2
-    dev: false
 
   /braces@3.0.2:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
@@ -2297,6 +2250,7 @@ packages:
 
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+    dev: true
 
   /fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -2363,16 +2317,6 @@ packages:
       once: 1.4.0
       path-is-absolute: 1.0.1
     dev: true
-
-  /glob@9.3.5:
-    resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
-    engines: {node: '>=16 || 14 >=14.17'}
-    dependencies:
-      fs.realpath: 1.0.0
-      minimatch: 8.0.4
-      minipass: 4.2.8
-      path-scurry: 1.10.1
-    dev: false
 
   /global-dirs@0.1.1:
     resolution: {integrity: sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg==}
@@ -2981,6 +2925,7 @@ packages:
   /lru-cache@10.0.1:
     resolution: {integrity: sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==}
     engines: {node: 14 || >=16.14}
+    dev: true
 
   /lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
@@ -3107,13 +3052,6 @@ packages:
       brace-expansion: 1.1.11
     dev: true
 
-  /minimatch@8.0.4:
-    resolution: {integrity: sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==}
-    engines: {node: '>=16 || 14 >=14.17'}
-    dependencies:
-      brace-expansion: 2.0.1
-    dev: false
-
   /minimist-options@4.1.0:
     resolution: {integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==}
     engines: {node: '>= 6'}
@@ -3130,16 +3068,6 @@ packages:
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
     dev: true
-
-  /minipass@4.2.8:
-    resolution: {integrity: sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==}
-    engines: {node: '>=8'}
-    dev: false
-
-  /minipass@7.0.3:
-    resolution: {integrity: sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg==}
-    engines: {node: '>=16 || 14 >=14.17'}
-    dev: false
 
   /mlly@1.4.0:
     resolution: {integrity: sha512-ua8PAThnTwpprIaU47EPeZ/bPUVp2QYBbWMphUQpVdBI3Lgqzm5KZQ45Agm3YJedHXaIHl6pBGabaLSUPPSptg==}
@@ -3564,14 +3492,6 @@ packages:
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
     dev: true
-
-  /path-scurry@1.10.1:
-    resolution: {integrity: sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==}
-    engines: {node: '>=16 || 14 >=14.17'}
-    dependencies:
-      lru-cache: 10.0.1
-      minipass: 7.0.3
-    dev: false
 
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -4704,11 +4624,6 @@ packages:
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
     dev: true
-
-  /yaml@2.3.1:
-    resolution: {integrity: sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==}
-    engines: {node: '>= 14'}
-    dev: false
 
   /yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,4 +1,3 @@
-import { classes } from '@warp-ds/css/component-classes/classes';
 import { preflights } from '#preflights';
 import { rules } from '#rules';
 import { shortcuts } from '#shortcuts';
@@ -11,7 +10,6 @@ import { postprocess } from '#postprocess';
  * @property {boolean} development // internal use only - force preflights(transform + resets) to be excluded and no external classes will be processed
  * @property {boolean} skipResets // force resets to be excluded from preflights
  * @property {boolean} externalizeClasses - if true forces external or 'core' classes to be excluded from the process.
- * @property {boolean} omitComponentClasses - if true forces component classes to be excluded from the process.
  * @property {Array} externalClasses - list of classes that will not be processed
  * @property {boolean} usePixels - use pixel spacing instead of rem
  */
@@ -23,8 +21,7 @@ import { postprocess } from '#postprocess';
 export function presetWarp(options = {}) {
   checkEnvironment();
   const externalizeClasses = options.externalizeClasses ?? !options.development; // 'true' by default
-  const safeExternalClasses = options.externalClasses || [];
-  const excludedClasses = options.omitComponentClasses ? [...classes, ...safeExternalClasses] : safeExternalClasses;
+  const externalClasses = options.externalClasses || [];
   const theme = useTheme(options);
   return {
     name: '@warp-ds/uno',
@@ -32,7 +29,7 @@ export function presetWarp(options = {}) {
     rules,
     variants,
     preflights: options.development ? [] : preflights(options.skipResets),
-    postprocess: postprocess(externalizeClasses, excludedClasses),
+    postprocess: postprocess(externalizeClasses, externalClasses),
     shortcuts,
   };
 }

--- a/test/__snapshots__/external-classes.js.snap
+++ b/test/__snapshots__/external-classes.js.snap
@@ -1,0 +1,23 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`external classes > externaliized class of mt-32 should be excluded from the css 1`] = `
+"/* layer: default */
+.mb-24{margin-bottom:2.4rem;}
+.mt-16{margin-top:1.6rem;}"
+`;
+
+exports[`external classes > externaliized class of mt-32 should be included if used with modifier 1`] = `
+"/* layer: default */
+.active\\\\:mt-32:active{margin-top:3.2rem;}
+@media (min-width: 480px){
+.sm\\\\:mt-32{margin-top:3.2rem;}
+}
+@media (min-width: 768px){
+.md\\\\:mt-32{margin-top:3.2rem;}
+}"
+`;
+
+exports[`external classes > externaliized classes of mt-32 and mb-32 should be excluded from the css 1`] = `
+"/* layer: default */
+.mt-16{margin-top:1.6rem;}"
+`;

--- a/test/__snapshots__/external-classes.js.snap
+++ b/test/__snapshots__/external-classes.js.snap
@@ -1,12 +1,12 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`external classes > externaliized class of mt-32 should be excluded from the css 1`] = `
+exports[`external classes > externalized class of mt-32 should be excluded from the css 1`] = `
 "/* layer: default */
 .mb-24{margin-bottom:2.4rem;}
 .mt-16{margin-top:1.6rem;}"
 `;
 
-exports[`external classes > externaliized class of mt-32 should be included if used with modifier 1`] = `
+exports[`external classes > externalized class of mt-32 should be included if used with modifier 1`] = `
 "/* layer: default */
 .active\\\\:mt-32:active{margin-top:3.2rem;}
 @media (min-width: 480px){
@@ -17,7 +17,7 @@ exports[`external classes > externaliized class of mt-32 should be included if u
 }"
 `;
 
-exports[`external classes > externaliized classes of mt-32 and mb-32 should be excluded from the css 1`] = `
+exports[`external classes > externalized classes of mt-32 and mb-32 should be excluded from the css 1`] = `
 "/* layer: default */
 .mt-16{margin-top:1.6rem;}"
 `;

--- a/test/external-classes.js
+++ b/test/external-classes.js
@@ -9,7 +9,7 @@ describe('external classes', () => {
     const { css } = await uno.generate(classes);
     expect(css).toMatchSnapshot();
   });
-  test('externaliized class of mt-32 should be excluded from the css', async ({ uno }) => {
+  test('externalized class of mt-32 should be excluded from the css', async ({ uno }) => {
     const classes = ['mt-16', 'mt-32', 'mb-24'];
     const { css } = await uno.generate(classes);
     expect(css).toMatchSnapshot();

--- a/test/external-classes.js
+++ b/test/external-classes.js
@@ -4,7 +4,7 @@ import { describe, expect, test } from 'vitest';
 setup({ externalizeClasses: true, externalClasses: ["mt-32", "mb-32"] });
 
 describe('external classes', () => {
-  test('externaliized classes of mt-32 and mb-32 should be excluded from the css', async ({ uno }) => {
+  test('externalized classes of mt-32 and mb-32 should be excluded from the css', async ({ uno }) => {
     const classes = ['mt-16', 'mt-32', 'mb-32'];
     const { css } = await uno.generate(classes);
     expect(css).toMatchSnapshot();

--- a/test/external-classes.js
+++ b/test/external-classes.js
@@ -1,0 +1,22 @@
+import { setup } from './_helpers.js';
+import { describe, expect, test } from 'vitest';
+
+setup({ externalizeClasses: true, externalClasses: ["mt-32", "mb-32"] });
+
+describe('external classes', () => {
+  test('externaliized classes of mt-32 and mb-32 should be excluded from the css', async ({ uno }) => {
+    const classes = ['mt-16', 'mt-32', 'mb-32'];
+    const { css } = await uno.generate(classes);
+    expect(css).toMatchSnapshot();
+  });
+  test('externaliized class of mt-32 should be excluded from the css', async ({ uno }) => {
+    const classes = ['mt-16', 'mt-32', 'mb-24'];
+    const { css } = await uno.generate(classes);
+    expect(css).toMatchSnapshot();
+  });
+  test('externaliized class of mt-32 should be included if used with modifier', async ({ uno }) => {
+    const classes = ['sm:mt-32', 'md:mt-32', 'active:mt-32'];
+    const { css } = await uno.generate(classes);
+    expect(css).toMatchSnapshot();
+  });
+});

--- a/test/external-classes.js
+++ b/test/external-classes.js
@@ -14,7 +14,7 @@ describe('external classes', () => {
     const { css } = await uno.generate(classes);
     expect(css).toMatchSnapshot();
   });
-  test('externaliized class of mt-32 should be included if used with modifier', async ({ uno }) => {
+  test('externalized class of mt-32 should be included if used with modifier', async ({ uno }) => {
     const classes = ['sm:mt-32', 'md:mt-32', 'active:mt-32'];
     const { css } = await uno.generate(classes);
     expect(css).toMatchSnapshot();


### PR DESCRIPTION
`@warp-ds/css` dependency was only used to import component classes array and “externalize” those to avoid generating redundant CSS when it’s already available in an app through [components.css](https://assets.finn.no/pkg/@warp-ds/css/v1/components.css).
Until we figure out how to fix externalizing of component classes in a better way, we remove the option `omitComponentClasses` from the plugin. The users will then need to import the `@warp-ds/css` package and pass the imported component classes array to `externalClasses` option of `presetWarp` to achieve the same goal.