### PR TITLE
fix(aspect-ratio): add rules for aspect-ratio, -video and -square

### DIFF
--- a/src/_rules/aspect-ratio.js
+++ b/src/_rules/aspect-ratio.js
@@ -19,4 +19,12 @@ export const arBackport = [
     const child = `.${selector}>*{${childStyles}}`;
     return base + child;
   }, { autocomplete: ['aspect-(ratio)'] }],
+  [/^aspect-(video|square)$/, ([_selector, v]) => {
+    const fraction = v === "video" ? "16/9" : "1/1";
+    const ratioAsPercentage = h.inverseFraction(fraction);
+    const base = `.${_selector}{position:relative;padding-bottom:${ratioAsPercentage};}`;
+    const child = `.${_selector}>*{${childStyles}}`;
+    return base + child;
+  }, { autocomplete: ['aspect-(ratio)'] }],
+  ['aspect-ratio', { 'aspect-ratio': 'auto' }],
 ];

--- a/test/__snapshots__/aspect-ratio.js.snap
+++ b/test/__snapshots__/aspect-ratio.js.snap
@@ -1,5 +1,12 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`aspect-ratio, -video and -square 1`] = `
+"/* layer: default */
+.aspect-square{position:relative;padding-bottom:100%;}.aspect-square>*{position:absolute;height:100%;width:100%;top:0;right:0;bottom:0;left:0;}
+.aspect-video{position:relative;padding-bottom:56.25%;}.aspect-video>*{position:absolute;height:100%;width:100%;top:0;right:0;bottom:0;left:0;}
+.aspect-ratio{aspect-ratio:auto;}"
+`;
+
 exports[`it generates backported aspect-ratios 1`] = `
 "/* layer: default */
 .aspect-1\\\\/1{position:relative;padding-bottom:100%;}.aspect-1\\\\/1>*{position:absolute;height:100%;width:100%;top:0;right:0;bottom:0;left:0;}

--- a/test/aspect-ratio.js
+++ b/test/aspect-ratio.js
@@ -8,3 +8,9 @@ test('it generates backported aspect-ratios', async ({ uno }) => {
   const { css } = await uno.generate(classes);
   expect(css).toMatchSnapshot();
 });
+
+test('aspect-ratio, -video and -square', async ({ uno }) => {
+  const classes = ['aspect-ratio', 'aspect-video', 'aspect-square'];
+  const { css } = await uno.generate(classes);
+  expect(css).toMatchSnapshot();
+});


### PR DESCRIPTION
fixes #116 

Aspect ratio support is currently provided via the ['padding-bottom'](https://css-tricks.com/aspect-ratio-boxes/) fallback method. The built-in `aspect-ratio` property is not yet well supported, but for `aspect-ratio` utility class I couldn't find a better way to handle it than by generating this CSS: `.aspect-ratio { aspect-ratio: auto; }`.