### PR TITLE
chore: set next as prerelease branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - alpha
       - beta
       - next
 jobs:

--- a/.github/workflows/update-next.yml
+++ b/.github/workflows/update-next.yml
@@ -1,4 +1,4 @@
-name: Update alpha
+name: Update next
 on:
   workflow_run:
     workflows:
@@ -12,9 +12,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Rebase alpha to master
+      - name: Rebase next to master
         run: |
           git fetch --unshallow
-          git checkout alpha
+          git checkout next
           git rebase origin/master
           git push

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,7 +1,6 @@
 {
   "branches": [
     { "name": "master" },
-    { "name": "alpha", "prerelease": true },
     { "name": "beta", "prerelease": true },
     { "name": "next", "prerelease": true }
   ],

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,8 +105,8 @@ publishing when making changes to the `master` or `next` branch.
 Please note that the version published will depend on your commit message structure.
 Make sure to review and follow the instructions in the [Committing](#committing) section before committing.
 
-Before the first major release we develop against a `next` branch which is constantly published to [NPM](https://www.npmjs.com/package/@warp-ds/drive) a `next` tag (e.g. `1.0.0-next.1`).
-Anyone needing to start using the package before the main release can install the `next` version while waiting for the stable version.
+This project is continuously published to [NPM](https://www.npmjs.com/package/@warp-ds/drive) using a `next` tag (e.g. `1.1.0-next.1`).
+Anyone needing to use the latest changes of this package can install the `next` version while waiting for the stable release.
 
 A stable release from the `master` branch is basically done by just opening a pull request from `next` to `master` and then making sure to *merge* commit the pull request.
 NEVER SQUASH-MERGE TO `master` to prevent losing history and commit messages from all commits to `next`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,123 @@
+# Contributing to @warp-ds/drive
+
+Welcome to the [@warp-ds/drive](https://github.com/warp-ds/drive) repository!
+We're glad you're interested in contributing.
+
+This repository is mastertained by the [Warp Core Team](https://github.com/orgs/warp-ds/teams/warp-core-team)
+and is home to a UnoCSS plugin which defines rules, theme, preflights and other settings used for generating styles within the
+[Warp Design System](https://github.com/warp-ds/).
+
+To get an overview of the project, read the [README](README.md).
+
+
+## Development Setup
+
+To get started with developing [@warp-ds/drive](https://github.com/warp-ds/drive), follow the instructions below.
+This will walk you through setting up your development environment and running the tests.
+
+
+### Cloning the repository
+
+Start by cloning the repository to your dev environment by running:
+
+```sh
+git clone https://github.com/warp-ds/drive
+```
+
+
+### pnpm
+
+We use [pnpm](https://pnpm.io/) as package manager for Node.js.
+Install it by running:
+
+```sh
+npm install -g pnpm
+```
+
+
+### Dependencies
+
+Install dependencies by running:
+
+```sh
+pnpm install
+```
+
+
+### Run the plugin
+
+You can use the plugin from your teminal to generate CSS for utility classes.
+Run `pnpm dev` using the following instructions:
+
+Usage: node dev.js [--cliClasses=string | -c string] [--usePixels] [--externalClasses=string] [--externalizeClasses]
+
+Example: 
+```sh
+pnpm dev -c m-2
+```
+
+! Do not use `-c` when passing negative values, e.g. `pnpm dev --cliClasses='-m-2! gap-2'`
+
+## Contributing
+
+### Branching
+
+There are two branches to keep in mind:
+- `next` : used for pre-releases.
+- `master` : the master branch, used for stable releases.
+
+When adding a new feature, fixing a bug, or adding to the repository in any other way,
+you should always do this in a feature branch that is branched off the `next` branch.
+
+### Committing
+
+It is important to follow [Conventional Commits](https://www.conventionalcommits.org/) when making changes ([Commitizen](#commitizen) to the rescue),
+as this is used in the [automated release process](#releases).
+
+### Pull Request
+
+When your changes are ready for pull request, this should be opened against the `next` branch.
+Add the [Warp Core Team](https://github.com/orgs/warp-ds/teams/warp-core-team) as reviewer.
+
+Pull request to the `next` branch should always be set to *squash*.
+Make sure that the squash commit message follows the instructions in the [Committing](#committing) section before squash merging the pull request.
+
+### Commitizen
+
+We use [commitizen](https://github.com/commitizen/cz-cli) to ensure coherent commit message structure.
+This is used to automatically generate change logs and handle versioning when [releasing](#releases).
+
+```sh
+npm install -g commitizen
+```
+
+When installed, you should be able to type `cz` or `git cz` in your terminal to commit your changes (replacing
+`git commit`).
+
+[![Add and commit with Commitizen](https://github.com/commitizen/cz-cli/raw/master/meta/screenshots/add-commit.png)](https://github.com/commitizen/cz-cli/raw/master/meta/screenshots/add-commit.png)
+
+
+## Releases
+
+This project uses [Semantic Release](https://github.com/semantic-release/semantic-release) to automate package
+publishing when making changes to the `master` or `next` branch.
+
+Please note that the version published will depend on your commit message structure.
+Make sure to review and follow the instructions in the [Committing](#committing) section before committing.
+
+Before the first major release we develop against a `next` branch which is constantly published to [NPM](https://www.npmjs.com/package/@warp-ds/drive) a `next` tag (e.g. `1.0.0-next.1`).
+Anyone needing to start using the package before the main release can install the `next` version while waiting for the stable version.
+
+A stable release from the `master` branch is basically done by just opening a pull request from `next` to `master` and then making sure to *merge* commit the pull request.
+NEVER SQUASH-MERGE TO `master` to prevent losing history and commit messages from all commits to `next`.
+
+To avoid git history divergence between `next` and `master`,
+when a stable release from `master` results in a semantic-release-bot commit being pushed to `master`,
+a GitHub action automatically rebases `next` to `origin/master` after every release from `master`.
+
+( For reference, see this rfc in Fabric-ds: [RFC: Fabric Releases and Release Schedule](https://github.com/fabric-ds/issues/blob/779d59723993c13d62374516259602d967da56ca/rfcs/0004-releases.md) )
+
+## License
+
+@warp-ds/drive is [Apache-2.0 licensed](https://github.com/warp-ds/react/blob/master/LICENSE).
+By contributing to @warp-ds/react, you agree that your contributions will be licensed under its Apache-2.0 license.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
-# drive - an UnoCSS preset
+# drive - a UnoCSS preset
 
-## use
+## How to contribute
 
-## plugin API
+If you'd like to contribute to `@warp-ds/drive`, start by reviewing the [contributing guidelines](https://github.com/warp-ds/drive/blob/main/CONTRIBUTING.md).
+
+
+## Plugin API
 
 ### development
 
@@ -12,51 +15,53 @@
 ### skipResets
 
 - `boolean`
-- If true forces resets to be excluded from preflights
+- If true forces resets.css to be excluded from preflights
 
 ### usePixels
 
 - `boolean`
 - Internal use only, for use on sites that are incompatible with root REM/`font-size` changes
 
-## migration development
+### externalizeClasses
 
-## checking fabric classes
+- Forces classes in `externalClasses` to be removed from output
+
+### externalClasses
+
+- A list of CSS classes that should be removed from output
+
+
+## Quick test of utility classes support
+
+In order to generate CSS for utility classes from your terminal, run `pnpm dev` using the following instructions:
+
+Usage: node dev.js [--cliClasses=string | -c string] [--usePixels] [--externalClasses=string] [--externalizeClasses]
+
+Example: 
+```sh
+pnpm dev -c m-2
+```
+! Do not use `-c` when passing negative values, e.g. `pnpm dev --cliClasses='-m-2! gap-2'`
+
+## Migration development
+
+### checking fabric classes
 
 1. Check out the `parity` project from warp-ds, get dependencies for the project
-2. Link to the `parity` project from the `plugin` folder (this folder): `pnpm link ../parity`
+2. Link to the `parity` project from drive's root folder: `pnpm link ../parity`
 3. Run `node checkFabricClasses.js`
-
-## generating warp classes using command line
-
-Run `node dev.js` or `pnpm dev`
-
-Usage: node dev.js [-c <string> | --cliClasses=<string>] [--usePixels] [--development] [--externalClasses] [--externalizeClasses] [--usePreflight]
-
-Example: `node dev.js --usePixels --development --cliClasses=m-2`
-! Do not use shortcut when passing negative values, e.g. `node dev.js --cliClasses='-m-2! gap-2'`
-
-## Contributing
-
-We use [commitizen](https://github.com/commitizen/cz-cli) to ensure coherent commit message structure, used by [semantic release](#releases) to generate change logs and handle versioning.
-
-```
-npm install -g commitizen
-```
-
-When installed, you should be able to type `cz` or `git cz` in your terminal to commit your changes (replacing
-`git commit`).
-
-[![Add and commit with Commitizen](https://github.com/commitizen/cz-cli/raw/master/meta/screenshots/add-commit.png)](https://github.com/commitizen/cz-cli/raw/master/meta/screenshots/add-commit.png)
-
 
 ## Releases
 
-This project uses [Semantic Release](https://github.com/semantic-release/semantic-release) to automate package
-publishing when making changes to the `master` or `alpha` branch.
+This project is continuously published to [NPM](https://www.npmjs.com/package/@warp-ds/drive), also using a `next` tag (e.g. `1.0.0-next.1`).
+Anyone needing to start using the package before the main release can install the `next` version while waiting for the stable version.
 
-It is recommended to branch off the `alpha` branch and follow
-[conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) when making changes. When your
-changes are ready for pull request, this should be opened against the `alpha` branch.
 
-Please note that the version published will depend on your commit message structure. Make sure to use commitizen (see [Development section](#Contributing)).
+## Changelog
+
+Detailed changes for each release can be found in the [CHANGELOG](CHANGELOG.md) file.
+
+
+## License
+
+@warp-ds/drive is available under the [Apache-2.0 software license](https://github.com/warp-ds/drive/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ pnpm dev -c m-2
 
 ## Releases
 
-This project is continuously published to [NPM](https://www.npmjs.com/package/@warp-ds/drive), also using a `next` tag (e.g. `1.0.0-next.1`).
-Anyone needing to start using the package before the main release can install the `next` version while waiting for the stable version.
+This project is continuously published to [NPM](https://www.npmjs.com/package/@warp-ds/drive) using a `next` tag (e.g. `1.1.0-next.1`).
+Anyone needing to use the latest changes of this package can install the `next` version while waiting for the stable release.
 
 
 ## Changelog

--- a/dev.js
+++ b/dev.js
@@ -20,9 +20,6 @@ const {
     usePixels: {
       type: 'boolean',
     },
-    skipResets: {
-      type: 'boolean',
-    },
   },
 });
 


### PR DESCRIPTION
Changes included:
- Add `CONTRIBUTING.md`
- update github workflows to use `next` instead of `alpha`
- update `README.md` with instructions on contribution to align with other Warp packages

- [x] !!! Update base branch to `next` before merging this PR (`next` must be branched off `master` after the major release PR is out)
- [x] Update branch settings to default to `next`
