### PR TITLE
fix: update vite to 4.2.3 to fix a vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "semantic-release": "^20.1.1",
     "unocss": "^0.55.1",
     "uvu": "^0.5.6",
-    "vite": "^4.2.0",
+    "vite": "^4.2.3",
     "vitest": "^0.29.3"
   },
   "eslintConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,13 +42,13 @@ devDependencies:
     version: 20.1.1
   unocss:
     specifier: ^0.55.1
-    version: 0.55.1(postcss@8.4.28)(rollup@3.19.1)(vite@4.2.0)
+    version: 0.55.1(postcss@8.4.28)(rollup@3.19.1)(vite@4.2.3)
   uvu:
     specifier: ^0.5.6
     version: 0.5.6
   vite:
-    specifier: ^4.2.0
-    version: 4.2.0(@types/node@20.4.7)
+    specifier: ^4.2.3
+    version: 4.2.3(@types/node@20.4.7)
   vitest:
     specifier: ^0.29.3
     version: 0.29.3
@@ -868,7 +868,7 @@ packages:
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
     dev: true
 
-  /@unocss/astro@0.55.1(rollup@3.19.1)(vite@4.2.0):
+  /@unocss/astro@0.55.1(rollup@3.19.1)(vite@4.2.3):
     resolution: {integrity: sha512-t3eibW16Dx+Wck8rkQ2+Xt4z1y5XoiS5jXcKqHRV9GqhbG9IyY7/Rp3nyBoHGZSAnZhdczjgBB9xnU2W6X7tAA==}
     peerDependencies:
       vite: ^2.9.0 || ^3.0.0-0 || ^4.0.0
@@ -878,8 +878,8 @@ packages:
     dependencies:
       '@unocss/core': 0.55.1
       '@unocss/reset': 0.55.1
-      '@unocss/vite': 0.55.1(rollup@3.19.1)(vite@4.2.0)
-      vite: 4.2.0(@types/node@20.4.7)
+      '@unocss/vite': 0.55.1(rollup@3.19.1)(vite@4.2.3)
+      vite: 4.2.3(@types/node@20.4.7)
     transitivePeerDependencies:
       - rollup
     dev: true
@@ -1065,7 +1065,7 @@ packages:
       '@unocss/core': 0.55.1
     dev: true
 
-  /@unocss/vite@0.55.1(rollup@3.19.1)(vite@4.2.0):
+  /@unocss/vite@0.55.1(rollup@3.19.1)(vite@4.2.3):
     resolution: {integrity: sha512-wf1YZBk/Pw0poo3QBXXCCwM7qq83lXoKNdqKVui5H+iCa0haRkscHX6/2PmJVRgczdpCG9/kFl3tDI3KzQdOkA==}
     peerDependencies:
       vite: ^2.9.0 || ^3.0.0-0 || ^4.0.0
@@ -1080,7 +1080,7 @@ packages:
       chokidar: 3.5.3
       fast-glob: 3.3.1
       magic-string: 0.30.2
-      vite: 4.2.0(@types/node@20.4.7)
+      vite: 4.2.3(@types/node@20.4.7)
     transitivePeerDependencies:
       - rollup
     dev: true
@@ -4327,7 +4327,7 @@ packages:
     engines: {node: '>= 10.0.0'}
     dev: true
 
-  /unocss@0.55.1(postcss@8.4.28)(rollup@3.19.1)(vite@4.2.0):
+  /unocss@0.55.1(postcss@8.4.28)(rollup@3.19.1)(vite@4.2.3):
     resolution: {integrity: sha512-WyLlrkB1m37LT3jmT51BOmvcd2/aFL0/QuJLn0gYQUWHi28uPtGFTL2kEvivqxzEgDgDrzbQl8VBgy1RssbRHQ==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -4339,7 +4339,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      '@unocss/astro': 0.55.1(rollup@3.19.1)(vite@4.2.0)
+      '@unocss/astro': 0.55.1(rollup@3.19.1)(vite@4.2.3)
       '@unocss/cli': 0.55.1(rollup@3.19.1)
       '@unocss/core': 0.55.1
       '@unocss/extractor-arbitrary-variants': 0.55.1
@@ -4358,8 +4358,8 @@ packages:
       '@unocss/transformer-compile-class': 0.55.1
       '@unocss/transformer-directives': 0.55.1
       '@unocss/transformer-variant-group': 0.55.1
-      '@unocss/vite': 0.55.1(rollup@3.19.1)(vite@4.2.0)
-      vite: 4.2.0(@types/node@20.4.7)
+      '@unocss/vite': 0.55.1(rollup@3.19.1)(vite@4.2.3)
+      vite: 4.2.3(@types/node@20.4.7)
     transitivePeerDependencies:
       - postcss
       - rollup
@@ -4414,7 +4414,7 @@ packages:
       mlly: 1.4.0
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 4.2.0(@types/node@20.5.0)
+      vite: 4.2.3(@types/node@20.5.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -4425,8 +4425,8 @@ packages:
       - terser
     dev: true
 
-  /vite@4.2.0(@types/node@20.4.7):
-    resolution: {integrity: sha512-AbDTyzzwuKoRtMIRLGNxhLRuv1FpRgdIw+1y6AQG73Q5+vtecmvzKo/yk8X/vrHDpETRTx01ABijqUHIzBXi0g==}
+  /vite@4.2.3(@types/node@20.4.7):
+    resolution: {integrity: sha512-kLU+m2q0Y434Y1kCy3TchefAdtFso0ILi0dLyFV8Us3InXTU11H/B5ZTqCKIQHzSKNxVG/yEx813EA9f1imQ9A==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:
@@ -4459,8 +4459,8 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vite@4.2.0(@types/node@20.5.0):
-    resolution: {integrity: sha512-AbDTyzzwuKoRtMIRLGNxhLRuv1FpRgdIw+1y6AQG73Q5+vtecmvzKo/yk8X/vrHDpETRTx01ABijqUHIzBXi0g==}
+  /vite@4.2.3(@types/node@20.5.0):
+    resolution: {integrity: sha512-kLU+m2q0Y434Y1kCy3TchefAdtFso0ILi0dLyFV8Us3InXTU11H/B5ZTqCKIQHzSKNxVG/yEx813EA9f1imQ9A==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:
@@ -4536,7 +4536,7 @@ packages:
       tinybench: 2.5.0
       tinypool: 0.3.1
       tinyspy: 1.1.1
-      vite: 4.2.0(@types/node@20.5.0)
+      vite: 4.2.3(@types/node@20.5.0)
       vite-node: 0.29.3(@types/node@20.5.0)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:


### PR DESCRIPTION
More on the issue here: https://github.com/warp-ds/drive/security/dependabot/6