### PR TITLE
feat: Add rules for backdrop-blur

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -64,8 +64,6 @@ These are TW2 selectors, TW3 and other utility CSS have moved on in syntax.
 
 # Filters
 
-All filters
-
 - filter
 - filter-none
 - blur-sm
@@ -120,13 +118,6 @@ All filters
 - sepia
 - backdrop-filter
 - backdrop-filter-none
-- backdrop-blur-sm
-- backdrop-blur
-- backdrop-blur-md
-- backdrop-blur-lg
-- backdrop-blur-xl
-- backdrop-blur-2xl
-- backdrop-blur-3xl
 - backdrop-brightness-0
 - backdrop-brightness-50
 - backdrop-brightness-75

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -118,6 +118,11 @@ These are TW2 selectors, TW3 and other utility CSS have moved on in syntax.
 - sepia
 - backdrop-filter
 - backdrop-filter-none
+- backdrop-blur-sm :: prefer backdrop-blur-s
+- backdrop-blur-md :: prefer backdrop-blur-m
+- backdrop-blur-lg :: prefer backdrop-blur-l
+- backdrop-blur-2xl :: prefer backdrop-blur-xxl
+- backdrop-blur-3xl :: prefer backdrop-blur-xxxl
 - backdrop-brightness-0
 - backdrop-brightness-50
 - backdrop-brightness-75

--- a/src/_rules/backdrop.js
+++ b/src/_rules/backdrop.js
@@ -1,0 +1,15 @@
+const blurSize = {
+  none: '0',
+  s: '2px',
+  default: '4px',
+  m: '8px',
+  l: '12px',
+  xl: '16px',
+  xxl: '24px',
+  xxxl: '40px',
+};
+
+export const backdrop = [
+  [/^backdrop-blur$/, () => ({ '-webkit-backdrop-filter': `blur(${blurSize.default})`, 'backdrop-filter': `blur(${blurSize.default})` })],
+  [/^backdrop-blur-(none|s|m|l|xl|xxl|xxxl)$/, ([, size]) => ({ '-webkit-backdrop-filter': `blur(${blurSize[size]})`, 'backdrop-filter': `blur(${blurSize[size]})` })],
+];

--- a/src/_rules/index.js
+++ b/src/_rules/index.js
@@ -2,6 +2,7 @@ import * as align from "./align.js";
 import * as animations from "./animations.js";
 import * as arbitrary from "./arbitrary.js";
 import * as aspectRatio from "./aspect-ratio.js";
+import * as backdrop from './backdrop.js';
 import * as backgrounds from './background.js';
 import * as behaviors from "./behaviors.js";
 import * as border from "./border.js";
@@ -35,6 +36,7 @@ const ruleGroups = {
   ...animations,
   ...arbitrary,
   ...aspectRatio,
+  ...backdrop,
   ...backgrounds,
   ...behaviors,
   ...border,
@@ -72,6 +74,7 @@ export * from "./align.js";
 export * from "./animations.js";
 export * from "./arbitrary.js";
 export * from "./aspect-ratio.js";
+export * from './backdrop.js';
 export * from './background.js';
 export * from "./behaviors.js";
 export * from "./border.js";

--- a/test/__snapshots__/backdrop.js.snap
+++ b/test/__snapshots__/backdrop.js.snap
@@ -1,0 +1,13 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`backdrop blur 1`] = `
+"/* layer: default */
+.backdrop-blur{-webkit-backdrop-filter:blur(4px);backdrop-filter:blur(4px);}
+.backdrop-blur-l{-webkit-backdrop-filter:blur(12px);backdrop-filter:blur(12px);}
+.backdrop-blur-m{-webkit-backdrop-filter:blur(8px);backdrop-filter:blur(8px);}
+.backdrop-blur-none{-webkit-backdrop-filter:blur(0);backdrop-filter:blur(0);}
+.backdrop-blur-s{-webkit-backdrop-filter:blur(2px);backdrop-filter:blur(2px);}
+.backdrop-blur-xl{-webkit-backdrop-filter:blur(16px);backdrop-filter:blur(16px);}
+.backdrop-blur-xxl{-webkit-backdrop-filter:blur(24px);backdrop-filter:blur(24px);}
+.backdrop-blur-xxxl{-webkit-backdrop-filter:blur(40px);backdrop-filter:blur(40px);}"
+`;

--- a/test/backdrop.js
+++ b/test/backdrop.js
@@ -1,0 +1,28 @@
+import { setup } from './_helpers.js';
+import { expect, test } from 'vitest';
+
+setup();
+
+test('backdrop blur', async ({ uno }) => {
+  const classes = [
+    'backdrop-blur-none',
+    'backdrop-blur',
+    'backdrop-blur-s',
+    'backdrop-blur-m',
+    'backdrop-blur-l',
+    'backdrop-blur-xl',
+    'backdrop-blur-xxl',
+    'backdrop-blur-xxxl',
+  ];
+  const antiClasses = [
+    'backdrop-blur-',
+    'backdrop-blur-4',
+    'backdrop-blur-inherit',
+    'backdrop-blur-sm',
+    'backdrop-blur-lg',
+    'backdrop-blur-xl2',
+    'backdrop-blur-3xl',
+  ];
+  const { css } = await uno.generate([...classes, ...antiClasses]);
+  expect(css).toMatchSnapshot();
+});


### PR DESCRIPTION
New rules for backdrop-blur based on:
https://tailwindcss.com/docs/backdrop-blur
(though the blur sizes has been modified and also size names are changed to align with how it is in warp)