### PR TITLE
feat: add variantPartClasses to _variants

### DIFF
--- a/src/_variants/index.js
+++ b/src/_variants/index.js
@@ -5,6 +5,7 @@ import {
   variantTaggedPseudoClasses,
   variantPseudoClassFunctions,
   variantPseudoClassesAndElements,
+  variantPartClasses
 } from '@unocss/preset-mini/variants';
 import { variantSpaceAndDivide } from './spaceAndDivide.js';
 import { variantLastChild } from './lastChild.js';
@@ -17,6 +18,7 @@ export const variants = [
   variantPseudoClassFunctions(),
   variantPseudoClassesAndElements(),
   variantSpaceAndDivide,
+  variantPartClasses,
   ...variantTaggedPseudoClasses({ attributifyPseudo: false }),
 ];
 
@@ -29,4 +31,5 @@ export {
   variantPseudoClassesAndElements,
   variantSpaceAndDivide,
   variantTaggedPseudoClasses,
+  variantPartClasses,
 };

--- a/src/_variants/index.js
+++ b/src/_variants/index.js
@@ -5,7 +5,7 @@ import {
   variantTaggedPseudoClasses,
   variantPseudoClassFunctions,
   variantPseudoClassesAndElements,
-  variantPartClasses
+  variantPartClasses,
 } from '@unocss/preset-mini/variants';
 import { variantSpaceAndDivide } from './spaceAndDivide.js';
 import { variantLastChild } from './lastChild.js';

--- a/test/__snapshots__/variants.js.snap
+++ b/test/__snapshots__/variants.js.snap
@@ -39,6 +39,7 @@ exports[`variants > negative 1`] = `
 exports[`variants > pseudo 1`] = `
 "/* layer: default */
 .focus\\\\:border:focus{border-width:1px;}
+.part-\\\\[part-name\\\\]\\\\:s-bg-primary::part(part-name){background-color:var(--w-s-color-background-primary);}
 .group:hover .group-hover\\\\:p-16{padding:1.6rem;}
 .before\\\\:p-32::before{padding:3.2rem;}
 .group\\\\/llama:hover .group-hover\\\\/llama\\\\:m-32{margin:3.2rem;}

--- a/test/variants.js
+++ b/test/variants.js
@@ -20,7 +20,7 @@ describe('variants', () => {
     expect(css).toMatchSnapshot();
   });
   test('pseudo', async ({ uno }) => {
-    const classes = ['last:mb-0', 'before:p-32', 'focus:border', 'group', 'group-hover:p-16', 'group/llama', 'group-hover/llama:m-32'];
+    const classes = ['last:mb-0', 'before:p-32', 'focus:border', 'group', 'group-hover:p-16', 'group/llama', 'group-hover/llama:m-32', 'part-[part-name]:s-bg-primary'];
     const { css } = await uno.generate(classes);
     expect(css).toMatchSnapshot();
   });


### PR DESCRIPTION
Add `variantPartClasses` to _variants

**Note:** This is part of implementing changes to the expandable-component in the elements-repo in order to be able to style the svg from a warp-icon that is inside a shadow-DOM using the [CSS pseudo-element part](https://developer.mozilla.org/en-US/docs/Web/CSS/::part) that is also supported by unoCSS.