### PR TITLE
feat(rules): add support for outline color classes

### DIFF
--- a/src/_rules/focus-ring.js
+++ b/src/_rules/focus-ring.js
@@ -2,7 +2,7 @@ import { entriesToCss, escapeSelector } from '@unocss/core';
 
 // TODO: use actual variables and values when those has been defined
 const focusRingStyle = entriesToCss(Object.entries({
-  outline: '2px solid var(--w-s-color-focused)',
+  outline: '2px solid var(--w-s-color-border-focused, var(--w-s-color-focused))',
   'outline-offset': 'var(--w-outline-offset, 1px)',
 }));
 

--- a/src/_rules/semantic.js
+++ b/src/_rules/semantic.js
@@ -15,5 +15,6 @@ export const semanticRules = [
   [/^s-border-([lrtbxy])-(.+)$/, ([, direction, cssvar]) => directionMap[direction]?.map(
     (dir) => [`border${dir}-color`, h.semanticToken(`border-${cssvar}`)],
   )],
+  [/^s-outline$/, () => ({ 'outline-color': h.semanticToken('border') })],
   [/^s-outline-(.+)$/, ([, cssvar]) => ({ 'outline-color': h.semanticToken(`border-${cssvar}`) })],
 ];

--- a/src/_rules/semantic.js
+++ b/src/_rules/semantic.js
@@ -15,4 +15,5 @@ export const semanticRules = [
   [/^s-border-([lrtbxy])-(.+)$/, ([, direction, cssvar]) => directionMap[direction]?.map(
     (dir) => [`border${dir}-color`, h.semanticToken(`border-${cssvar}`)],
   )],
+  [/^s-outline-(.+)$/, ([, cssvar]) => ({ 'outline-color': h.semanticToken(`border-${cssvar}`) })],
 ];

--- a/test/__snapshots__/semantic.js.snap
+++ b/test/__snapshots__/semantic.js.snap
@@ -32,5 +32,7 @@ exports[`it generates css based on semantic warp tokens 1`] = `
 .s-border-r-primary-selected-hover{border-right-color:var(--w-s-color-border-primary-selected-hover);}
 .s-border-t-positive{border-top-color:var(--w-s-color-border-positive);}
 .s-border-x-warning-active{border-left-color:var(--w-s-color-border-warning-active);border-right-color:var(--w-s-color-border-warning-active);}
-.s-border-y-info-subtle-active{border-top-color:var(--w-s-color-border-info-subtle-active);border-bottom-color:var(--w-s-color-border-info-subtle-active);}"
+.s-border-y-info-subtle-active{border-top-color:var(--w-s-color-border-info-subtle-active);border-bottom-color:var(--w-s-color-border-info-subtle-active);}
+.s-outline-focused{outline-color:var(--w-s-color-border-focused);}
+.s-outline-negative{outline-color:var(--w-s-color-border-negative);}"
 `;

--- a/test/__snapshots__/semantic.js.snap
+++ b/test/__snapshots__/semantic.js.snap
@@ -33,6 +33,7 @@ exports[`it generates css based on semantic warp tokens 1`] = `
 .s-border-t-positive{border-top-color:var(--w-s-color-border-positive);}
 .s-border-x-warning-active{border-left-color:var(--w-s-color-border-warning-active);border-right-color:var(--w-s-color-border-warning-active);}
 .s-border-y-info-subtle-active{border-top-color:var(--w-s-color-border-info-subtle-active);border-bottom-color:var(--w-s-color-border-info-subtle-active);}
+.s-outline{outline-color:var(--w-s-color-border);}
 .s-outline-focused{outline-color:var(--w-s-color-border-focused);}
 .s-outline-negative{outline-color:var(--w-s-color-border-negative);}"
 `;

--- a/test/focus-ring.js
+++ b/test/focus-ring.js
@@ -16,10 +16,10 @@ test("focus ring", async (t) => {
 
   expect(css).toMatchInlineSnapshot(`
     "/* layer: default */
-    .focus-within\\\\:focusable:focus-within{outline:2px solid var(--w-s-color-focused);outline-offset:var(--w-outline-offset, 1px);}
-    .focusable:focus,.focusable:focus-visible{outline:2px solid var(--w-s-color-focused);outline-offset:var(--w-outline-offset, 1px);}.focusable:not(:focus-visible){outline:none;}
-    .group:focus .group-focus\\\\:focusable,.group:focus-visible .group-focus\\\\:focusable{outline:2px solid var(--w-s-color-focused);outline-offset:var(--w-outline-offset, 1px);}.group:not(:focus-visible) .group-focus\\\\:focusable{outline:none;}
-    .peer:focus~.peer-focus\\\\:focusable,.peer:focus-visible~.peer-focus\\\\:focusable{outline:2px solid var(--w-s-color-focused);outline-offset:var(--w-outline-offset, 1px);}.peer:not(:focus-visible)~.peer-focus\\\\:focusable{outline:none;}
+    .focus-within\\\\:focusable:focus-within{outline:2px solid var(--w-s-color-border-focused, var(--w-s-color-focused));outline-offset:var(--w-outline-offset, 1px);}
+    .focusable:focus,.focusable:focus-visible{outline:2px solid var(--w-s-color-border-focused, var(--w-s-color-focused));outline-offset:var(--w-outline-offset, 1px);}.focusable:not(:focus-visible){outline:none;}
+    .group:focus .group-focus\\\\:focusable,.group:focus-visible .group-focus\\\\:focusable{outline:2px solid var(--w-s-color-border-focused, var(--w-s-color-focused));outline-offset:var(--w-outline-offset, 1px);}.group:not(:focus-visible) .group-focus\\\\:focusable{outline:none;}
+    .peer:focus~.peer-focus\\\\:focusable,.peer:focus-visible~.peer-focus\\\\:focusable{outline:2px solid var(--w-s-color-border-focused, var(--w-s-color-focused));outline-offset:var(--w-outline-offset, 1px);}.peer:not(:focus-visible)~.peer-focus\\\\:focusable{outline:none;}
     .focusable-inset{--w-outline-offset:-3px;}"
   `);
 });

--- a/test/semantic.js
+++ b/test/semantic.js
@@ -22,6 +22,8 @@ test('it generates css based on semantic warp tokens', async ({ uno }) => {
     's-border-b-negative-hover',
     's-border-x-warning-active',
     's-border-y-info-subtle-active',
+    's-outline-focused',
+    's-outline-negative',
     's-icon',
     's-icon-hover',
     's-icon-active',

--- a/test/semantic.js
+++ b/test/semantic.js
@@ -22,6 +22,7 @@ test('it generates css based on semantic warp tokens', async ({ uno }) => {
     's-border-b-negative-hover',
     's-border-x-warning-active',
     's-border-y-info-subtle-active',
+    's-outline',
     's-outline-focused',
     's-outline-negative',
     's-icon',


### PR DESCRIPTION
Fixes [WARP-398](https://nmp-jira.atlassian.net/browse/WARP-398):

We should allow users to style the color of the outline in the same way as they can style border - using semantic color classes. We can for the time being reuse border color tokens, but since the focused outline color is currently assigned to a generic `--w-s-color-focused` token, we thought it’s better to have it as  `--w-s-color-border-focused` to make the border and outline color rules aligned. 

We're keeping the generic `--w-s-color-focused` token for backward compatibility, but we can indicate that it may be removed by setting the `--w-s-color-border-focused` on `focusable` with the previous CSS variable as fallback. I'm open to solving it in a different way. We haven't really spoken about the future of `--w-s-color-focused` 😄