### PR TITLE
feat: Add missing support for arbitrary and semantic colors

### DIFF
--- a/src/_rules/background.js
+++ b/src/_rules/background.js
@@ -38,14 +38,12 @@ export const backgrounds = [
   ...makeGlobalStaticRules('bg-origin', 'background-origin'),
 
   //arbitrary
-  [/^bg-\[(.+)\]/, ([, p]) => {
+  [/^bg-\[(.+)]/, ([, p]) => {
     if (p.startsWith('url')) {
       // Process url(var(--something)) and extract the var itself -> --something
       const urlAsVar = p.match(/url\(var\(([^)]*)/)?.[1];
       return { 'background-image': urlAsVar ? `var(${urlAsVar})` : p };
-    } else if (p.startsWith('var')) {
-      return { 'background-color': p };
     }
-    return { 'background-color': `var(${p})` };
+    return { 'background-color': p.startsWith('var') ? p : `var(${p})` };
   }],
 ];

--- a/src/_rules/border.js
+++ b/src/_rules/border.js
@@ -21,13 +21,14 @@ export const borders = [
   [/^border-inverted$/, () => ({ 'border-color': 'var(--w-s-border-inverted)' })],
   [/^border-inherit$/, () => ({ 'border-color': 'inherit' })],
   [/^border-current$/, () => ({ 'border-color': 'currentColor' })],
+  [/^border-\[(.+)]/, ([, p]) => ({ 'border-color': p.startsWith('var') ? p : `var(${p})` })],
   [/^border()-(\d+)$/, handlerBorder, { autocomplete: "(border)-<directions>" }],
   [/^border-([lrtbxy])$/, handlerBorder],
   [/^border-([lrtbxy])-(\d+)$/, handlerBorder],
   [/^border()-(.+)$/, handlerBorderStyle, { autocomplete: "(border)-style" }],
   [/^border-([lrtbxy])-(.+)$/, handlerBorderStyle],
   [
-    /^border-([lrtb])?-?\[(\d+)\]$/,
+    /^border-([lrtb])?-?\[(\d+)]$/,
     handlerArbitraryBorderSize,
     {
       autocomplete: [
@@ -39,6 +40,7 @@ export const borders = [
   [/^divide-([xy])-(\d+)$/, handlerDivideBorder, { autocomplete: `divide-<x|y>-(${Object.keys(lineWidth).join('|')})-(reverse)` }],
   [/^divide-([xy])$/, handlerDivideBorder],
   [/^divide-([xy])-reverse$/, ([, d]) => ({ [`--w-divide-${d}-reverse`]: 1 })],
+  [/^divide-\[(.+)]/, ([_selector, p]) => `.${escapeSelector(_selector)}>*+*{border-color: ${p.startsWith('var') ? p : `var(${p})`};}`],
 ];
 
 function handlerBorder(m, ctx) {

--- a/src/_rules/border.js
+++ b/src/_rules/border.js
@@ -16,84 +16,100 @@ const borderStyles = [
 ];
 
 export const borders = [
-  [/^border$/, handlerBorder],
+  // border-width
+  [
+    /^border(-[lrtbxy])?$/,
+    handleBorderWidth,
+    { autocomplete: ['border', 'border-<directions>'] },
+  ],
+  [
+    /^border(-[lrtbxy])?-(\d+)$/,
+    handleBorderWidth,
+    { autocomplete: [`border-(${Object.keys(lineWidth).join('|')})`, `border-<directions>-(${Object.keys(lineWidth).join('|')})`] },
+  ],
+  [
+    /^border(-[lrtbxy])?-\[(\d+)]$/,
+    handleArbitraryBorderWidth,
+    { autocomplete: ['border-[<num>]', 'border-<directions>-[<num>]'] },
+  ],
+
+  // border-color
   [/^border-transparent$/, () => ({ 'border-color': 'transparent' })],
   [/^border-inverted$/, () => ({ 'border-color': 'var(--w-s-border-inverted)' })],
   [/^border-inherit$/, () => ({ 'border-color': 'inherit' })],
   [/^border-current$/, () => ({ 'border-color': 'currentColor' })],
-  [/^border-\[(.+)]/, ([, p]) => ({ 'border-color': p.startsWith('var') ? p : `var(${p})` })],
-  [/^border()-(\d+)$/, handlerBorder, { autocomplete: "(border)-<directions>" }],
-  [/^border-([lrtbxy])$/, handlerBorder],
-  [/^border-([lrtbxy])-(\d+)$/, handlerBorder],
-  [/^border()-(.+)$/, handlerBorderStyle, { autocomplete: "(border)-style" }],
-  [/^border-([lrtbxy])-(.+)$/, handlerBorderStyle],
+  [/^border(-[lrtbxy])?-\[(\D.*)]$/, handleArbitraryBorderColor],
+
+  // border-style
   [
-    /^border-([lrtb])?-?\[(\d+)]$/,
-    handlerArbitraryBorderSize,
-    {
-      autocomplete: [
-        'border-<directions>-[$width]',
-      ],
-    },
+    new RegExp(`^border(-[lrtbxy])?-(${borderStyles.join('|')})$`),
+    handleBorderStyle,
+    { autocomplete: [`border-(${borderStyles.join('|')})`, `border-<directions>-(${borderStyles.join('|')})`] },
   ],
-  // divide
-  [/^divide-([xy])-(\d+)$/, handlerDivideBorder, { autocomplete: `divide-<x|y>-(${Object.keys(lineWidth).join('|')})-(reverse)` }],
-  [/^divide-([xy])$/, handlerDivideBorder],
-  [/^divide-([xy])-reverse$/, ([, d]) => ({ [`--w-divide-${d}-reverse`]: 1 })],
-  [/^divide-\[(.+)]/, ([_selector, p]) => `.${escapeSelector(_selector)}>*+*{border-color: ${p.startsWith('var') ? p : `var(${p})`};}`],
 ];
 
-function handlerBorder(m, ctx) {
-  const borderSizes = handlerBorderSize(m, ctx);
-
-  if (borderSizes ) return [...borderSizes];
+function handleBorderWidth([, dir = '', width], { theme }) {
+  const applicableWidth = theme.lineWidth?.[width ?? 1];
+  if (applicableWidth) return directionMap[dir.substring(1)]?.map((i) => [`border${i}-width`, applicableWidth]);
 }
 
-function handlerBorderSize([, a = "", b], { theme }) {
-  const v = theme.lineWidth?.[b ?? 1];
-  if (a in directionMap && v != null) return directionMap[a].map((i) => [`border${i}-width`, v]);
+function handleArbitraryBorderWidth([, dir = '', width]) {
+  //TODO: Use the usePixels flag to determine which unit to use
+  return directionMap[dir.substring(1)]?.map((i) => [`border${i}-width`, `${width}px`]);
 }
 
-function handlerArbitraryBorderSize([, a, v]) {
-  if (a in directionMap && v != null) return directionMap[a].map((i) => [`border${i}-width`, `${v}px`]);
-
-  return [[`border-width`, `${v}px`]];
+function handleArbitraryBorderColor([, dir = '', val]) {
+  const cssvar = val.startsWith('var') ? val : `var(${val})`;
+  return directionMap[dir.substring(1)]?.map((i) => [`border${i}-color`, cssvar]);
 }
 
-function handlerBorderStyle([, a = "", s]) {
-  if (borderStyles.includes(s) && a in directionMap) return directionMap[a].map((i) => [`border${i}-style`, s]);
+function handleBorderStyle([, dir = '', style]) {
+  return directionMap[dir.substring(1)]?.map((i) => [`border${i}-style`, style]);
+}
+
+export const divide = [
+  // border-width
+  [/^divide-([xy])$/, handleDivideBorder, { autocomplete: 'divide-(x|y)' }],
+  [
+    /^divide-([xy])-(\d+)(-reverse)?$/,
+    handleDivideBorder,
+    { autocomplete: [`divide-(x|y)-(${Object.keys(lineWidth).join('|')})`, `divide-(x|y)-(${Object.keys(lineWidth).join('|')})-reverse`] },
+  ],
+
+  // reverse order
+  [/^divide-([xy])-reverse$/, ([, d]) => ({ [`--w-divide-${d}-reverse`]: 1 })],
+
+  // arbitrary border-color
+  [/^divide(-[xy])?-\[(.+)]$/, handleArbitraryDivideColor],
+];
+
+function handleDivideBorder([_selector, dir, width, reverse], { theme }) {
+  const applicableWidth = theme.lineWidth?.[width ?? 1];
+  if (applicableWidth) {
+    const sizes = directionMap[dir]?.map((i) => {
+      const reverseVar = `var(--w-divide-${dir}-reverse)`;
+      const reverseCalc = (i === directionMap[dir][1]) ? reverseVar : `calc(1 - ${reverseVar})`;
+      return `border${i}-width:calc(${applicableWidth} * ${reverseCalc})`;
+    });
+    if (sizes) {
+      return `.${escapeSelector(_selector)}>*+*{--w-divide-${dir}-reverse:${reverse ? 1 : 0};${sizes.join(';')};}`;
+    }
+  }
+}
+
+function handleArbitraryDivideColor([_selector, dir = '', val]) {
+  const cssRules = directionMap[dir.substring(1)]?.map((i) => `border${i}-color: ${val.startsWith('var') ? val : `var(${val})`}`);
+  if (cssRules) return `.${escapeSelector(_selector)}>*+*{${cssRules.join(';')};}`;
 }
 
 export const rounded = [
-  [/^rounded()(?:-(.+))?$/, handlerRounded, { autocomplete: ['(rounded)', '(rounded)-<num>'] }],
-  [/^rounded-([rltb]+)(?:-(.+))?$/, handlerRounded],
-  [/^rounded-([bi][se])(?:-(.+))?$/, handlerRounded],
-  [/^rounded-([bi][se]-[bi][se])(?:-(.+))?$/, handlerRounded],
+  [/^rounded()(?:-(.+))?$/, handleRounded, { autocomplete: ['rounded', 'rounded-<num>'] }],
+  [/^rounded-([rltb]+)(?:-(.+))?$/, handleRounded],
+  [/^rounded-([bi][se])(?:-(.+))?$/, handleRounded],
+  [/^rounded-([bi][se]-[bi][se])(?:-(.+))?$/, handleRounded],
 ];
 
-function handlerRounded([, a = '', s], { theme }) {
-  const v = theme.borderRadius?.[s ?? 4];
-  if (a in cornerMap && v != null) return cornerMap[a].map(i => [`border${i}-radius`, v]);
+function handleRounded([, corner = '', val], { theme }) {
+  const applicableRadius = theme.borderRadius?.[val ?? 4];
+  if (applicableRadius) return cornerMap[corner].map(i => [`border${i}-radius`, applicableRadius]);
 }
-
-function handleDivideBorderSizes(direction, width, reverse, theme) {
-  const borderWidth = theme.lineWidth?.[width ?? 1];
-  if (direction in directionMap && borderWidth) {
-    return directionMap[direction].map((i) => {
-      if (i === directionMap[direction][1]) {
-        return `border${i}-width:calc(${borderWidth} * var(--w-divide-${direction}-reverse))`;
-      }
-      return `border${i}-width:calc(${borderWidth} * calc(1 - var(--w-divide-${direction}-reverse)))`;
-    });
-  }
-}
-
-function handlerDivideBorder([_selector, direction = "", width, reverse], { theme }) {
-  const sizes = handleDivideBorderSizes(direction, width, reverse, theme)?.join(';');
-  const defaultReverse = `--w-divide-${direction}-reverse:0`;
-  if (sizes) {
-    const selector = escapeSelector(_selector);
-    return `.${selector}>*+*{${defaultReverse};${sizes}}`;
-  }
-}
-

--- a/src/_rules/color.js
+++ b/src/_rules/color.js
@@ -12,6 +12,7 @@ export const textColors = [
 //  ['text-inherit', { 'color': 'inherit' }], // This class currently sets "text-align: inherit;" in align.js
   ['text-transparent', { 'color': 'transparent' }],
   ['text-current', { 'color': 'currentColor' }],
+  [/^text-\[(.+)]/, ([, p]) => ({ 'color': p.startsWith('var') ? p : `var(${p})` })],
 ];
 
 export const bgColors = [

--- a/src/_rules/focus-ring.js
+++ b/src/_rules/focus-ring.js
@@ -1,6 +1,6 @@
 import { entriesToCss, escapeSelector } from '@unocss/core';
 
-// TODO: use actual variables and values when those has been defined
+// TODO: Remove deprecated fallback (--w-s-color-focused) in v2
 const focusRingStyle = entriesToCss(Object.entries({
   outline: '2px solid var(--w-s-color-border-focused, var(--w-s-color-focused))',
   'outline-offset': 'var(--w-outline-offset, 1px)',

--- a/src/_rules/outline.js
+++ b/src/_rules/outline.js
@@ -5,6 +5,13 @@ const outlineNone = {
   'outline-offset': '2px',
 };
 
+export const outlineColors = [
+  ['outline-inherit', { 'outline-color': 'inherit' }],
+  ['outline-transparent', { 'outline-color': 'transparent' }],
+  ['outline-current', { 'outline-color': 'currentColor' }],
+  [/^outline-\[(.+)]/, ([, p]) => ({ 'outline-color': p.startsWith('var') ? p : `var(${p})` })],
+];
+
 export const outlineStyle = [
   ["outline-none", { ...outlineNone }],
   ["outline", { "outline-style": "solid" }],

--- a/src/_rules/semantic.js
+++ b/src/_rules/semantic.js
@@ -1,4 +1,5 @@
 import { directionMap, handler as h } from '#utils';
+import { escapeSelector } from "@unocss/core";
 
 export const semanticRules = [
   [/^s-bg$/, () => ({ 'background-color': h.semanticToken('background') })],
@@ -17,4 +18,6 @@ export const semanticRules = [
   )],
   [/^s-outline$/, () => ({ 'outline-color': h.semanticToken('border') })],
   [/^s-outline-(.+)$/, ([, cssvar]) => ({ 'outline-color': h.semanticToken(`border-${cssvar}`) })],
+  [/^s-divide$/, ([_selector]) => `.${escapeSelector(_selector)}>*+*{border-color: ${h.semanticToken('border')};}`],
+  [/^s-divide-(.+)$/, ([_selector, cssvar]) => `.${escapeSelector(_selector)}>*+*{border-color: ${h.semanticToken(`border-${cssvar}`)};}`],
 ];

--- a/test/__snapshots__/background.js.snap
+++ b/test/__snapshots__/background.js.snap
@@ -1,5 +1,14 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`bg arbitrary 1`] = `
+"/* layer: default */
+.bg-\\\\[url\\\\(\\\\'\\\\/img\\\\/hero-pattern\\\\.svg\\\\'\\\\)\\\\]{background-image:url('/img/hero-pattern.svg');}
+.bg-\\\\[url\\\\(\\\\\\"\\\\/img\\\\/hero-pattern\\\\.svg\\\\\\"\\\\)\\\\]{background-image:url(\\"/img/hero-pattern.svg\\");}
+.bg-\\\\[url\\\\(\\\\\\"data\\\\:image\\\\/svg\\\\+xml\\\\,\\\\%3csvg\\\\ xmlns\\\\=\\\\'http\\\\:\\\\/\\\\/www\\\\.w3\\\\.org\\\\/2000\\\\/svg\\\\'\\\\ viewBox\\\\=\\\\'0\\\\ 0\\\\ 16\\\\ 16\\\\'\\\\ fill\\\\=\\\\'white\\\\'\\\\%3e\\\\%3cpath\\\\ d\\\\=\\\\'M12\\\\.207\\\\ 4\\\\.793a1\\\\ 1\\\\ 0\\\\ 010\\\\ 1\\\\.414l-5\\\\ 5a1\\\\ 1\\\\ 0\\\\ 01-1\\\\.414\\\\ 0l-2-2a1\\\\ 1\\\\ 0\\\\ 011\\\\.414-1\\\\.414L6\\\\.5\\\\ 9\\\\.086l4\\\\.293-4\\\\.293a1\\\\ 1\\\\ 0\\\\ 011\\\\.414\\\\ 0z\\\\'\\\\/\\\\%3e\\\\%3c\\\\/svg\\\\%3e\\\\\\"\\\\)\\\\]{background-image:url(\\"data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='white'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e\\");}
+.peer:checked~.peer-checked\\\\:before\\\\:bg-\\\\[url\\\\(\\\\'data\\\\:image\\\\/svg\\\\+xml\\\\,\\\\%3Csvg\\\\ width\\\\=\\\\\\"16\\\\\\"\\\\ height\\\\=\\\\\\"16\\\\\\"\\\\ viewBox\\\\=\\\\\\"0\\\\ 0\\\\ 16\\\\ 16\\\\\\"\\\\ fill\\\\=\\\\\\"none\\\\\\"\\\\ xmlns\\\\=\\\\\\"http\\\\:\\\\/\\\\/www\\\\.w3\\\\.org\\\\/2000\\\\/svg\\\\\\"\\\\%3E\\\\%3Cpath\\\\ d\\\\=\\\\\\"M4\\\\ 8L7\\\\ 11L12\\\\.5\\\\ 5\\\\\\"\\\\ stroke\\\\=\\\\\\"\\\\%2371717A\\\\\\"\\\\ stroke-width\\\\=\\\\\\"1\\\\.5\\\\\\"\\\\ stroke-linecap\\\\=\\\\\\"round\\\\\\"\\\\ stroke-linejoin\\\\=\\\\\\"round\\\\\\"\\\\/\\\\%3E\\\\%3C\\\\/svg\\\\%3E\\\\'\\\\)\\\\]::before{background-image:url('data:image/svg+xml,%3Csvg width=\\"16\\" height=\\"16\\" viewBox=\\"0 0 16 16\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"%3E%3Cpath d=\\"M4 8L7 11L12.5 5\\" stroke=\\"%2371717A\\" stroke-width=\\"1.5\\" stroke-linecap=\\"round\\" stroke-linejoin=\\"round\\"/%3E%3C/svg%3E');}
+.before\\\\:bg-\\\\[url\\\\(var\\\\(--w-form-check-mark\\\\)\\\\)\\\\]::before{background-image:var(--w-form-check-mark);}"
+`;
+
 exports[`bg attachments 1`] = `
 "/* layer: default */
 .bg-fixed{background-attachment:fixed;}
@@ -76,4 +85,10 @@ exports[`bg size 1`] = `
 .bg-auto{background-size:auto;}
 .bg-cover{background-size:cover;}
 .bg-contain{background-size:contain;}"
+`;
+
+exports[`supports setting arbitrary background colors 1`] = `
+"/* layer: default */
+.bg-\\\\[--w-s-color-background\\\\],
+.bg-\\\\[var\\\\(--w-s-color-background\\\\)\\\\]{background-color:var(--w-s-color-background);}"
 `;

--- a/test/__snapshots__/border.js.snap
+++ b/test/__snapshots__/border.js.snap
@@ -50,6 +50,12 @@ exports[`border > supports divide borders between horizontal and stacked childre
 .divide-y>*+*{--w-divide-y-reverse:0;border-top-width:calc(1px * calc(1 - var(--w-divide-y-reverse)));border-bottom-width:calc(1px * var(--w-divide-y-reverse))}"
 `;
 
+exports[`border > supports setting arbitrary border colors 1`] = `
+"/* layer: default */
+.border-\\\\[--w-s-color-border\\\\],
+.border-\\\\[var\\\\(--w-s-color-border\\\\)\\\\]{border-color:var(--w-s-color-border);}"
+`;
+
 exports[`border > supports setting arbitrary border width 1`] = `
 "/* layer: default */
 .border-\\\\[6\\\\]{border-width:6px;}
@@ -58,6 +64,12 @@ exports[`border > supports setting arbitrary border width 1`] = `
 .border-l-\\\\[7\\\\]{border-left-width:7px;}
 .border-r-\\\\[7\\\\]{border-right-width:7px;}
 .border-t-\\\\[7\\\\]{border-top-width:7px;}"
+`;
+
+exports[`border > supports setting arbitrary divide colors 1`] = `
+"/* layer: default */
+.divide-\\\\[--w-s-color-border\\\\]>*+*{border-color: var(--w-s-color-border);}
+.divide-\\\\[var\\\\(--w-s-color-border\\\\)\\\\]>*+*{border-color: var(--w-s-color-border);}"
 `;
 
 exports[`border > supports setting border color 1`] = `

--- a/test/__snapshots__/border.js.snap
+++ b/test/__snapshots__/border.js.snap
@@ -26,16 +26,16 @@ exports[`border > right, left, top bottom 1`] = `
 
 exports[`border > supports divide borders between horizontal and stacked children 1`] = `
 "/* layer: default */
-.divide-x-0>*+*{--w-divide-x-reverse:0;border-left-width:calc(0 * calc(1 - var(--w-divide-x-reverse)));border-right-width:calc(0 * var(--w-divide-x-reverse))}
-.divide-x-1>*+*{--w-divide-x-reverse:0;border-left-width:calc(1px * calc(1 - var(--w-divide-x-reverse)));border-right-width:calc(1px * var(--w-divide-x-reverse))}
-.divide-x-2>*+*{--w-divide-x-reverse:0;border-left-width:calc(2px * calc(1 - var(--w-divide-x-reverse)));border-right-width:calc(2px * var(--w-divide-x-reverse))}
-.divide-x-4>*+*{--w-divide-x-reverse:0;border-left-width:calc(4px * calc(1 - var(--w-divide-x-reverse)));border-right-width:calc(4px * var(--w-divide-x-reverse))}
-.divide-x-8>*+*{--w-divide-x-reverse:0;border-left-width:calc(8px * calc(1 - var(--w-divide-x-reverse)));border-right-width:calc(8px * var(--w-divide-x-reverse))}
-.divide-y-0>*+*{--w-divide-y-reverse:0;border-top-width:calc(0 * calc(1 - var(--w-divide-y-reverse)));border-bottom-width:calc(0 * var(--w-divide-y-reverse))}
-.divide-y-1>*+*{--w-divide-y-reverse:0;border-top-width:calc(1px * calc(1 - var(--w-divide-y-reverse)));border-bottom-width:calc(1px * var(--w-divide-y-reverse))}
-.divide-y-2>*+*{--w-divide-y-reverse:0;border-top-width:calc(2px * calc(1 - var(--w-divide-y-reverse)));border-bottom-width:calc(2px * var(--w-divide-y-reverse))}
-.divide-y-4>*+*{--w-divide-y-reverse:0;border-top-width:calc(4px * calc(1 - var(--w-divide-y-reverse)));border-bottom-width:calc(4px * var(--w-divide-y-reverse))}
-.divide-y-8>*+*{--w-divide-y-reverse:0;border-top-width:calc(8px * calc(1 - var(--w-divide-y-reverse)));border-bottom-width:calc(8px * var(--w-divide-y-reverse))}"
+.divide-x-0>*+*{--w-divide-x-reverse:0;border-left-width:calc(0 * calc(1 - var(--w-divide-x-reverse)));border-right-width:calc(0 * var(--w-divide-x-reverse));}
+.divide-x-1>*+*{--w-divide-x-reverse:0;border-left-width:calc(1px * calc(1 - var(--w-divide-x-reverse)));border-right-width:calc(1px * var(--w-divide-x-reverse));}
+.divide-x-2>*+*{--w-divide-x-reverse:0;border-left-width:calc(2px * calc(1 - var(--w-divide-x-reverse)));border-right-width:calc(2px * var(--w-divide-x-reverse));}
+.divide-x-4>*+*{--w-divide-x-reverse:0;border-left-width:calc(4px * calc(1 - var(--w-divide-x-reverse)));border-right-width:calc(4px * var(--w-divide-x-reverse));}
+.divide-x-8>*+*{--w-divide-x-reverse:0;border-left-width:calc(8px * calc(1 - var(--w-divide-x-reverse)));border-right-width:calc(8px * var(--w-divide-x-reverse));}
+.divide-y-0>*+*{--w-divide-y-reverse:0;border-top-width:calc(0 * calc(1 - var(--w-divide-y-reverse)));border-bottom-width:calc(0 * var(--w-divide-y-reverse));}
+.divide-y-1>*+*{--w-divide-y-reverse:0;border-top-width:calc(1px * calc(1 - var(--w-divide-y-reverse)));border-bottom-width:calc(1px * var(--w-divide-y-reverse));}
+.divide-y-2>*+*{--w-divide-y-reverse:0;border-top-width:calc(2px * calc(1 - var(--w-divide-y-reverse)));border-bottom-width:calc(2px * var(--w-divide-y-reverse));}
+.divide-y-4>*+*{--w-divide-y-reverse:0;border-top-width:calc(4px * calc(1 - var(--w-divide-y-reverse)));border-bottom-width:calc(4px * var(--w-divide-y-reverse));}
+.divide-y-8>*+*{--w-divide-y-reverse:0;border-top-width:calc(8px * calc(1 - var(--w-divide-y-reverse)));border-bottom-width:calc(8px * var(--w-divide-y-reverse));}"
 `;
 
 exports[`border > supports divide borders between horizontal and stacked children in reverse order 1`] = `
@@ -46,8 +46,8 @@ exports[`border > supports divide borders between horizontal and stacked childre
 
 exports[`border > supports divide borders between horizontal and stacked children, default width 1`] = `
 "/* layer: default */
-.divide-x>*+*{--w-divide-x-reverse:0;border-left-width:calc(1px * calc(1 - var(--w-divide-x-reverse)));border-right-width:calc(1px * var(--w-divide-x-reverse))}
-.divide-y>*+*{--w-divide-y-reverse:0;border-top-width:calc(1px * calc(1 - var(--w-divide-y-reverse)));border-bottom-width:calc(1px * var(--w-divide-y-reverse))}"
+.divide-x>*+*{--w-divide-x-reverse:0;border-left-width:calc(1px * calc(1 - var(--w-divide-x-reverse)));border-right-width:calc(1px * var(--w-divide-x-reverse));}
+.divide-y>*+*{--w-divide-y-reverse:0;border-top-width:calc(1px * calc(1 - var(--w-divide-y-reverse)));border-bottom-width:calc(1px * var(--w-divide-y-reverse));}"
 `;
 
 exports[`border > supports setting arbitrary border colors 1`] = `
@@ -69,7 +69,9 @@ exports[`border > supports setting arbitrary border width 1`] = `
 exports[`border > supports setting arbitrary divide colors 1`] = `
 "/* layer: default */
 .divide-\\\\[--w-s-color-border\\\\]>*+*{border-color: var(--w-s-color-border);}
-.divide-\\\\[var\\\\(--w-s-color-border\\\\)\\\\]>*+*{border-color: var(--w-s-color-border);}"
+.divide-\\\\[var\\\\(--w-s-color-border-subtle\\\\)\\\\]>*+*{border-color: var(--w-s-color-border-subtle);}
+.divide-x-\\\\[var\\\\(--w-s-color-border-negative\\\\)\\\\]>*+*{border-left-color: var(--w-s-color-border-negative);border-right-color: var(--w-s-color-border-negative);}
+.divide-y-\\\\[var\\\\(--w-s-color-border-positive\\\\)\\\\]>*+*{border-top-color: var(--w-s-color-border-positive);border-bottom-color: var(--w-s-color-border-positive);}"
 `;
 
 exports[`border > supports setting border color 1`] = `

--- a/test/__snapshots__/color.js.snap
+++ b/test/__snapshots__/color.js.snap
@@ -23,6 +23,14 @@ exports[`opacity by theme 1`] = `
 .opacity-75{opacity:75%;}"
 `;
 
+exports[`supports setting arbitrary background colors 1`] = `""`;
+
+exports[`supports setting arbitrary background colors 2`] = `
+"/* layer: default */
+.border-\\\\[--w-s-color-border\\\\],
+.border-\\\\[var\\\\(--w-s-color-border\\\\)\\\\]{border-color:var(--w-s-color-border);}"
+`;
+
 exports[`text colors 1`] = `
 "/* layer: default */
 .text-transparent{color:transparent;}

--- a/test/__snapshots__/color.js.snap
+++ b/test/__snapshots__/color.js.snap
@@ -23,18 +23,6 @@ exports[`opacity by theme 1`] = `
 .opacity-75{opacity:75%;}"
 `;
 
-exports[`supports setting arbitrary background colors 1`] = `
-"/* layer: default */
-.bg-\\\\[--w-s-color-background\\\\],
-.bg-\\\\[var\\\\(--w-s-color-background\\\\)\\\\]{background-color:var(--w-s-color-background);}"
-`;
-
-exports[`supports setting arbitrary border colors 1`] = `
-"/* layer: default */
-.border-\\\\[--w-s-color-border\\\\],
-.border-\\\\[var\\\\(--w-s-color-border\\\\)\\\\]{border-color:var(--w-s-color-border);}"
-`;
-
 exports[`supports setting arbitrary text colors 1`] = `
 "/* layer: default */
 .text-\\\\[--w-s-color-border\\\\],

--- a/test/__snapshots__/color.js.snap
+++ b/test/__snapshots__/color.js.snap
@@ -23,9 +23,13 @@ exports[`opacity by theme 1`] = `
 .opacity-75{opacity:75%;}"
 `;
 
-exports[`supports setting arbitrary background colors 1`] = `""`;
+exports[`supports setting arbitrary background colors 1`] = `
+"/* layer: default */
+.bg-\\\\[--w-s-color-background\\\\],
+.bg-\\\\[var\\\\(--w-s-color-background\\\\)\\\\]{background-color:var(--w-s-color-background);}"
+`;
 
-exports[`supports setting arbitrary background colors 2`] = `
+exports[`supports setting arbitrary border colors 1`] = `
 "/* layer: default */
 .border-\\\\[--w-s-color-border\\\\],
 .border-\\\\[var\\\\(--w-s-color-border\\\\)\\\\]{border-color:var(--w-s-color-border);}"

--- a/test/__snapshots__/color.js.snap
+++ b/test/__snapshots__/color.js.snap
@@ -35,6 +35,12 @@ exports[`supports setting arbitrary border colors 1`] = `
 .border-\\\\[var\\\\(--w-s-color-border\\\\)\\\\]{border-color:var(--w-s-color-border);}"
 `;
 
+exports[`supports setting arbitrary text colors 1`] = `
+"/* layer: default */
+.text-\\\\[--w-s-color-border\\\\],
+.text-\\\\[var\\\\(--w-s-color-border\\\\)\\\\]{color:var(--w-s-color-border);}"
+`;
+
 exports[`text colors 1`] = `
 "/* layer: default */
 .text-transparent{color:transparent;}

--- a/test/__snapshots__/outline.js.snap
+++ b/test/__snapshots__/outline.js.snap
@@ -18,6 +18,15 @@ exports[`outline > style 1`] = `
 .outline-double{outline-style:double;}"
 `;
 
+exports[`outline > supports setting arbitrary outline colors 1`] = `
+"/* layer: default */
+.outline-inherit{outline-color:inherit;}
+.outline-transparent{outline-color:transparent;}
+.outline-current{outline-color:currentColor;}
+.outline-\\\\[--w-s-color-border\\\\],
+.outline-\\\\[var\\\\(--w-s-color-border\\\\)\\\\]{outline-color:var(--w-s-color-border);}"
+`;
+
 exports[`outline > width 1`] = `
 "/* layer: default */
 .outline-0{outline-width:0;}

--- a/test/__snapshots__/outline.js.snap
+++ b/test/__snapshots__/outline.js.snap
@@ -9,22 +9,22 @@ exports[`outline > offset 1`] = `
 .outline-offset-8{outline-offset:8px;}"
 `;
 
-exports[`outline > style 1`] = `
-"/* layer: default */
-.outline-none{outline:2px solid transparent;outline-offset:2px;}
-.outline{outline-style:solid;}
-.outline-dashed{outline-style:dashed;}
-.outline-dotted{outline-style:dotted;}
-.outline-double{outline-style:double;}"
-`;
-
-exports[`outline > supports setting arbitrary outline colors 1`] = `
+exports[`outline > supports setting outline colors 1`] = `
 "/* layer: default */
 .outline-inherit{outline-color:inherit;}
 .outline-transparent{outline-color:transparent;}
 .outline-current{outline-color:currentColor;}
 .outline-\\\\[--w-s-color-border\\\\],
 .outline-\\\\[var\\\\(--w-s-color-border\\\\)\\\\]{outline-color:var(--w-s-color-border);}"
+`;
+
+exports[`outline > supports setting outline styles 1`] = `
+"/* layer: default */
+.outline-none{outline:2px solid transparent;outline-offset:2px;}
+.outline{outline-style:solid;}
+.outline-dashed{outline-style:dashed;}
+.outline-dotted{outline-style:dotted;}
+.outline-double{outline-style:double;}"
 `;
 
 exports[`outline > width 1`] = `

--- a/test/__snapshots__/semantic.js.snap
+++ b/test/__snapshots__/semantic.js.snap
@@ -35,5 +35,9 @@ exports[`it generates css based on semantic warp tokens 1`] = `
 .s-border-y-info-subtle-active{border-top-color:var(--w-s-color-border-info-subtle-active);border-bottom-color:var(--w-s-color-border-info-subtle-active);}
 .s-outline{outline-color:var(--w-s-color-border);}
 .s-outline-focused{outline-color:var(--w-s-color-border-focused);}
-.s-outline-negative{outline-color:var(--w-s-color-border-negative);}"
+.s-outline-negative{outline-color:var(--w-s-color-border-negative);}
+.s-divide>*+*{border-color: var(--w-s-color-border);}
+.s-divide-disabled>*+*{border-color: var(--w-s-color-border-disabled);}
+.s-divide-info-subtle-active>*+*{border-color: var(--w-s-color-border-info-subtle-active);}
+.s-divide-negative>*+*{border-color: var(--w-s-color-border-negative);}"
 `;

--- a/test/background.js
+++ b/test/background.js
@@ -49,27 +49,28 @@ test('bg clip', async ({ uno }) => {
 test('bg invalid', async ({ uno }) => {
   const classes = ['bg-white', 'bg-none'];
   const { css } = await uno.generate(classes);
-  expect(css).toMatchInlineSnapshot('""');
+  expect(css).toHaveLength(0);
 });
 
 test('bg arbitrary', async ({ uno }) => {
   const classes = [
     `bg-[url('/img/hero-pattern.svg')]`,
     `bg-[url("/img/hero-pattern.svg")]`,
-    `bg-[var(--w-color)]`,
     `before:bg-[url(var(--w-form-check-mark))]`,
-    `bg-[--w-color]`,
     `peer-checked:before:bg-[url('data:image/svg+xml,%3Csvg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M4 8L7 11L12.5 5" stroke="%2371717A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/%3E%3C/svg%3E')]`,
     `bg-[url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='white'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e")]`];
   const { css } = await uno.generate(classes);
-  expect(css).toMatchInlineSnapshot(`
-    "/* layer: default */
-    .bg-\\\\[--w-color\\\\],
-    .bg-\\\\[var\\\\(--w-color\\\\)\\\\]{background-color:var(--w-color);}
-    .bg-\\\\[url\\\\(\\\\'\\\\/img\\\\/hero-pattern\\\\.svg\\\\'\\\\)\\\\]{background-image:url('/img/hero-pattern.svg');}
-    .bg-\\\\[url\\\\(\\\\\\"\\\\/img\\\\/hero-pattern\\\\.svg\\\\\\"\\\\)\\\\]{background-image:url(\\"/img/hero-pattern.svg\\");}
-    .bg-\\\\[url\\\\(\\\\\\"data\\\\:image\\\\/svg\\\\+xml\\\\,\\\\%3csvg\\\\ xmlns\\\\=\\\\'http\\\\:\\\\/\\\\/www\\\\.w3\\\\.org\\\\/2000\\\\/svg\\\\'\\\\ viewBox\\\\=\\\\'0\\\\ 0\\\\ 16\\\\ 16\\\\'\\\\ fill\\\\=\\\\'white\\\\'\\\\%3e\\\\%3cpath\\\\ d\\\\=\\\\'M12\\\\.207\\\\ 4\\\\.793a1\\\\ 1\\\\ 0\\\\ 010\\\\ 1\\\\.414l-5\\\\ 5a1\\\\ 1\\\\ 0\\\\ 01-1\\\\.414\\\\ 0l-2-2a1\\\\ 1\\\\ 0\\\\ 011\\\\.414-1\\\\.414L6\\\\.5\\\\ 9\\\\.086l4\\\\.293-4\\\\.293a1\\\\ 1\\\\ 0\\\\ 011\\\\.414\\\\ 0z\\\\'\\\\/\\\\%3e\\\\%3c\\\\/svg\\\\%3e\\\\\\"\\\\)\\\\]{background-image:url(\\"data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='white'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e\\");}
-    .peer:checked~.peer-checked\\\\:before\\\\:bg-\\\\[url\\\\(\\\\'data\\\\:image\\\\/svg\\\\+xml\\\\,\\\\%3Csvg\\\\ width\\\\=\\\\\\"16\\\\\\"\\\\ height\\\\=\\\\\\"16\\\\\\"\\\\ viewBox\\\\=\\\\\\"0\\\\ 0\\\\ 16\\\\ 16\\\\\\"\\\\ fill\\\\=\\\\\\"none\\\\\\"\\\\ xmlns\\\\=\\\\\\"http\\\\:\\\\/\\\\/www\\\\.w3\\\\.org\\\\/2000\\\\/svg\\\\\\"\\\\%3E\\\\%3Cpath\\\\ d\\\\=\\\\\\"M4\\\\ 8L7\\\\ 11L12\\\\.5\\\\ 5\\\\\\"\\\\ stroke\\\\=\\\\\\"\\\\%2371717A\\\\\\"\\\\ stroke-width\\\\=\\\\\\"1\\\\.5\\\\\\"\\\\ stroke-linecap\\\\=\\\\\\"round\\\\\\"\\\\ stroke-linejoin\\\\=\\\\\\"round\\\\\\"\\\\/\\\\%3E\\\\%3C\\\\/svg\\\\%3E\\\\'\\\\)\\\\]::before{background-image:url('data:image/svg+xml,%3Csvg width=\\"16\\" height=\\"16\\" viewBox=\\"0 0 16 16\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\"%3E%3Cpath d=\\"M4 8L7 11L12.5 5\\" stroke=\\"%2371717A\\" stroke-width=\\"1.5\\" stroke-linecap=\\"round\\" stroke-linejoin=\\"round\\"/%3E%3C/svg%3E');}
-    .before\\\\:bg-\\\\[url\\\\(var\\\\(--w-form-check-mark\\\\)\\\\)\\\\]::before{background-image:var(--w-form-check-mark);}"
-  `);
+  expect(css).toMatchSnapshot();
+});
+
+test("supports setting arbitrary background colors", async ({ uno }) => {
+  const classes = ["bg-[--w-s-color-background]", "bg-[var(--w-s-color-background)]"];
+  const { css } = await uno.generate(classes);
+  expect(css).toMatchSnapshot();
+});
+
+test('invalid background color classes', async({ uno }) => {
+  const classes = ['bg-color', 'background-[--w-s-color-background]', 'background-[var(--w-s-color-background)]'];
+  const { css } = await uno.generate(classes);
+  expect(css).toHaveLength(0);
 });

--- a/test/border.js
+++ b/test/border.js
@@ -5,50 +5,50 @@ import { lineWidth } from '#theme';
 setup();
 
 describe("border", () => {
-  test("supports x|y with value and without", async (t) => {
+  test("supports x|y with value and without", async ({ uno }) => {
     const x = ["border-x", "border-x-0", "border-x-2", "border-x-4", "border-x-8"];
     const y = ["border-y", "border-y-0", "border-y-2", "border-y-4", "border-y-8"];
 
     const classes = [...x, ...y];
 
-    const { css } = await t.uno.generate(classes);
+    const { css } = await uno.generate(classes);
 
     expect(css).toMatchSnapshot();
   });
 
-  test("supports setting border width", async (t) => {
+  test("supports setting border width", async ({ uno }) => {
     const classes = ["border", "border-0", "border-2", "border-4", "border-8"];
 
-    const { css } = await t.uno.generate(classes);
+    const { css } = await uno.generate(classes);
 
     expect(css).toMatchSnapshot();
   });
 
-  test("supports setting arbitrary border width", async (t) => {
+  test("supports setting arbitrary border width", async ({ uno }) => {
     const classes = ["border-[66]", "border-[6]", "border-l-[7]", "border-r-[7]", "border-t-[7]", "border-b-[7]", "border-w-[7]"];
 
-    const { css } = await t.uno.generate(classes);
+    const { css } = await uno.generate(classes);
 
     expect(css).toMatchSnapshot();
   });
 
-  test("supports setting arbitrary border colors", async (t) => {
+  test("supports setting arbitrary border colors", async ({ uno }) => {
     const classes = ["border-[--w-s-color-border]", "border-[var(--w-s-color-border)]"];
 
-    const { css } = await t.uno.generate(classes);
+    const { css } = await uno.generate(classes);
 
     expect(css).toMatchSnapshot();
   });
 
-  test("supports setting arbitrary divide colors", async (t) => {
+  test("supports setting arbitrary divide colors", async ({ uno }) => {
     const classes = ["divide-[--w-s-color-border]", "divide-[var(--w-s-color-border)]"];
 
-    const { css } = await t.uno.generate(classes);
+    const { css } = await uno.generate(classes);
 
     expect(css).toMatchSnapshot();
   });
 
-  test("supports setting border style", async (t) => {
+  test("supports setting border style", async ({ uno }) => {
     const classes = [
       "border-solid",
       "border-dashed",
@@ -62,24 +62,24 @@ describe("border", () => {
       "border-outset",
     ];
 
-    const { css } = await t.uno.generate(classes);
+    const { css } = await uno.generate(classes);
 
     expect(css).toMatchSnapshot();
   });
 
-  test("supports setting border color", async (t) => {
+  test("supports setting border color", async ({ uno }) => {
     const classes = [
       "border-transparent",
       "border-inherit",
       "border-current",
     ];
 
-    const { css } = await t.uno.generate(classes);
+    const { css } = await uno.generate(classes);
 
     expect(css).toMatchSnapshot();
   });
 
-  test("right, left, top bottom", async (t) => {
+  test("right, left, top bottom", async ({ uno }) => {
     const right = [
       "border-r",
       "border-r-0",
@@ -114,7 +114,7 @@ describe("border", () => {
 
     const classes = [...right, ...left, ...top, ...bottom];
 
-    const { css } = await t.uno.generate(classes);
+    const { css } = await uno.generate(classes);
 
     expect(css).toMatchSnapshot();
   });
@@ -127,7 +127,7 @@ describe("border", () => {
   });
 
   test('supports divide borders between horizontal and stacked children in reverse order', async ({ uno }) => {
-    const classes = Object.keys(lineWidth).map(width => [`divide-x-reverse`, `divide-y-reverse`]).flat();
+    const classes = Object.keys(lineWidth).map(() => [`divide-x-reverse`, `divide-y-reverse`]).flat();
 
     const { css } = await uno.generate(classes);
     expect(css).toMatchSnapshot();
@@ -142,16 +142,16 @@ describe("border", () => {
     const classes = ['divide-x-10', 'divide-y-hej', 'divide-z-2-not-reverse'];
 
     const { css } = await uno.generate(classes);
-    expect(css).toMatchInlineSnapshot('""');
+    expect(css).toHaveLength(0);
   });
 
 });
 
 describe("rounded", () => {
-  test("supports x|y with value", async (t) => {
+  test("supports x|y with value", async ({ uno }) => {
     const classes = ["rounded", "rounded-0", "rounded-2", "rounded-4", "rounded-8", "rounded-16", "rounded-full", "rounded-t", "rounded-t-0", "rounded-t-2", "rounded-t-4", "rounded-t-8", "rounded-t-16", "rounded-t-full", "rounded-r", "rounded-r-0", "rounded-r-2", "rounded-r-4", "rounded-r-8", "rounded-r-16", "rounded-r-full", "rounded-b", "rounded-b-0", "rounded-b-2", "rounded-b-4", "rounded-b-8", "rounded-b-16", "rounded-b-full", "rounded-l", "rounded-l-0", "rounded-l-2", "rounded-l-4", "rounded-l-8", "rounded-l-16", "rounded-l-full", "rounded-tl-0", "rounded-tl-2", "rounded-tl-4", "rounded-tl-8", "rounded-tl-16", "rounded-tl-full", "rounded-tr-0", "rounded-tr-2", "rounded-tr-4", "rounded-tr-8", "rounded-tr-16", "rounded-tr-full", "rounded-br-0", "rounded-br-2", "rounded-br-4", "rounded-br-8", "rounded-br-16", "rounded-br-full", "rounded-bl-0", "rounded-bl-2", "rounded-bl-4", "rounded-bl-8", "rounded-bl-16", "rounded-bl-full"];
 
-    const { css } = await t.uno.generate(classes);
+    const { css } = await uno.generate(classes);
 
     expect(css).toMatchSnapshot();
   });

--- a/test/border.js
+++ b/test/border.js
@@ -32,7 +32,12 @@ describe("border", () => {
   });
 
   test("supports setting arbitrary divide colors", async ({ uno }) => {
-    const classes = ["divide-[--w-s-color-border]", "divide-[var(--w-s-color-border)]"];
+    const classes = [
+      "divide-[--w-s-color-border]",
+      "divide-[var(--w-s-color-border-subtle)]",
+      "divide-x-[var(--w-s-color-border-negative)]",
+      "divide-y-[var(--w-s-color-border-positive)]",
+    ];
     const { css } = await uno.generate(classes);
     expect(css).toMatchSnapshot();
   });

--- a/test/border.js
+++ b/test/border.js
@@ -25,12 +25,29 @@ describe("border", () => {
   });
 
   test("supports setting arbitrary border width", async (t) => {
-    const classes = ["border-[66]", "border-[6]", "border-l-[7]", "border-r-[7]", "border-t-[7]", "border-b-[7]", "border-w-[7]", "border-[wow]"];
+    const classes = ["border-[66]", "border-[6]", "border-l-[7]", "border-r-[7]", "border-t-[7]", "border-b-[7]", "border-w-[7]"];
 
     const { css } = await t.uno.generate(classes);
 
     expect(css).toMatchSnapshot();
   });
+
+  test("supports setting arbitrary border colors", async (t) => {
+    const classes = ["border-[--w-s-color-border]", "border-[var(--w-s-color-border)]"];
+
+    const { css } = await t.uno.generate(classes);
+
+    expect(css).toMatchSnapshot();
+  });
+
+  test("supports setting arbitrary divide colors", async (t) => {
+    const classes = ["divide-[--w-s-color-border]", "divide-[var(--w-s-color-border)]"];
+
+    const { css } = await t.uno.generate(classes);
+
+    expect(css).toMatchSnapshot();
+  });
+
   test("supports setting border style", async (t) => {
     const classes = [
       "border-solid",

--- a/test/border.js
+++ b/test/border.js
@@ -8,43 +8,32 @@ describe("border", () => {
   test("supports x|y with value and without", async ({ uno }) => {
     const x = ["border-x", "border-x-0", "border-x-2", "border-x-4", "border-x-8"];
     const y = ["border-y", "border-y-0", "border-y-2", "border-y-4", "border-y-8"];
-
     const classes = [...x, ...y];
-
     const { css } = await uno.generate(classes);
-
     expect(css).toMatchSnapshot();
   });
 
   test("supports setting border width", async ({ uno }) => {
     const classes = ["border", "border-0", "border-2", "border-4", "border-8"];
-
     const { css } = await uno.generate(classes);
-
     expect(css).toMatchSnapshot();
   });
 
   test("supports setting arbitrary border width", async ({ uno }) => {
     const classes = ["border-[66]", "border-[6]", "border-l-[7]", "border-r-[7]", "border-t-[7]", "border-b-[7]", "border-w-[7]"];
-
     const { css } = await uno.generate(classes);
-
     expect(css).toMatchSnapshot();
   });
 
   test("supports setting arbitrary border colors", async ({ uno }) => {
     const classes = ["border-[--w-s-color-border]", "border-[var(--w-s-color-border)]"];
-
     const { css } = await uno.generate(classes);
-
     expect(css).toMatchSnapshot();
   });
 
   test("supports setting arbitrary divide colors", async ({ uno }) => {
     const classes = ["divide-[--w-s-color-border]", "divide-[var(--w-s-color-border)]"];
-
     const { css } = await uno.generate(classes);
-
     expect(css).toMatchSnapshot();
   });
 
@@ -61,9 +50,7 @@ describe("border", () => {
       "border-inset",
       "border-outset",
     ];
-
     const { css } = await uno.generate(classes);
-
     expect(css).toMatchSnapshot();
   });
 
@@ -73,62 +60,28 @@ describe("border", () => {
       "border-inherit",
       "border-current",
     ];
-
     const { css } = await uno.generate(classes);
-
     expect(css).toMatchSnapshot();
   });
 
   test("right, left, top bottom", async ({ uno }) => {
-    const right = [
-      "border-r",
-      "border-r-0",
-      "border-r-2",
-      "border-r-4",
-      "border-r-8",
-    ];
-
-    const left = [
-      "border-l",
-      "border-l-0",
-      "border-l-2",
-      "border-l-4",
-      "border-l-8",
-    ];
-
-    const top = [
-      "border-t",
-      "border-t-0",
-      "border-t-2",
-      "border-t-4",
-      "border-t-8",
-    ];
-
-    const bottom = [
-      "border-b",
-      "border-b-0",
-      "border-b-2",
-      "border-b-4",
-      "border-b-8",
-    ];
-
+    const right = ["border-r", "border-r-0", "border-r-2", "border-r-4", "border-r-8"];
+    const left = ["border-l", "border-l-0", "border-l-2", "border-l-4", "border-l-8"];
+    const top = ["border-t", "border-t-0", "border-t-2", "border-t-4", "border-t-8"];
+    const bottom = ["border-b", "border-b-0", "border-b-2", "border-b-4", "border-b-8"];
     const classes = [...right, ...left, ...top, ...bottom];
-
     const { css } = await uno.generate(classes);
-
     expect(css).toMatchSnapshot();
   });
 
   test('supports divide borders between horizontal and stacked children', async ({ uno }) => {
     const classes = Object.keys(lineWidth).map(width => [`divide-x-${width}`, `divide-y-${width}`]).flat();
-
     const { css } = await uno.generate(classes);
     expect(css).toMatchSnapshot();
   });
 
   test('supports divide borders between horizontal and stacked children in reverse order', async ({ uno }) => {
     const classes = Object.keys(lineWidth).map(() => [`divide-x-reverse`, `divide-y-reverse`]).flat();
-
     const { css } = await uno.generate(classes);
     expect(css).toMatchSnapshot();
   });
@@ -140,19 +93,15 @@ describe("border", () => {
 
   test('does not support divide borders when invalid width provided', async ({ uno }) => {
     const classes = ['divide-x-10', 'divide-y-hej', 'divide-z-2-not-reverse'];
-
     const { css } = await uno.generate(classes);
     expect(css).toHaveLength(0);
   });
-
 });
 
 describe("rounded", () => {
   test("supports x|y with value", async ({ uno }) => {
     const classes = ["rounded", "rounded-0", "rounded-2", "rounded-4", "rounded-8", "rounded-16", "rounded-full", "rounded-t", "rounded-t-0", "rounded-t-2", "rounded-t-4", "rounded-t-8", "rounded-t-16", "rounded-t-full", "rounded-r", "rounded-r-0", "rounded-r-2", "rounded-r-4", "rounded-r-8", "rounded-r-16", "rounded-r-full", "rounded-b", "rounded-b-0", "rounded-b-2", "rounded-b-4", "rounded-b-8", "rounded-b-16", "rounded-b-full", "rounded-l", "rounded-l-0", "rounded-l-2", "rounded-l-4", "rounded-l-8", "rounded-l-16", "rounded-l-full", "rounded-tl-0", "rounded-tl-2", "rounded-tl-4", "rounded-tl-8", "rounded-tl-16", "rounded-tl-full", "rounded-tr-0", "rounded-tr-2", "rounded-tr-4", "rounded-tr-8", "rounded-tr-16", "rounded-tr-full", "rounded-br-0", "rounded-br-2", "rounded-br-4", "rounded-br-8", "rounded-br-16", "rounded-br-full", "rounded-bl-0", "rounded-bl-2", "rounded-bl-4", "rounded-bl-8", "rounded-bl-16", "rounded-bl-full"];
-
     const { css } = await uno.generate(classes);
-
     expect(css).toMatchSnapshot();
   });
 });

--- a/test/color.js
+++ b/test/color.js
@@ -51,14 +51,6 @@ test('bg colors', async({ uno }) => {
   expect(css).toMatchSnapshot();
 });
 
-test("supports setting arbitrary border colors", async (t) => {
-  const classes = ["border-[--w-s-color-border]", "border-[var(--w-s-color-border)]"];
-
-  const { css } = await t.uno.generate(classes);
-
-  expect(css).toMatchSnapshot();
-});
-
 test('invalid background color classes', async({ uno }) => {
   const classes = ['bg-color', 'background-[--w-s-color-background]', 'background-[var(--w-s-color-background)]'];
 

--- a/test/color.js
+++ b/test/color.js
@@ -33,14 +33,6 @@ test('text color invalid class', async({ uno }) => {
   expect(css).toMatchInlineSnapshot('""');
 });
 
-test("supports setting arbitrary background colors", async (t) => {
-  const classes = ["bg-[--w-s-color-background]", "bg-[var(--w-s-color-background)]"];
-
-  const { css } = await t.uno.generate(classes);
-
-  expect(css).toMatchSnapshot();
-});
-
 test('bg colors', async({ uno }) => {
   const classes = [
     'bg-inherit',
@@ -49,13 +41,6 @@ test('bg colors', async({ uno }) => {
 
   const { css } = await uno.generate(classes);
   expect(css).toMatchSnapshot();
-});
-
-test('invalid background color classes', async({ uno }) => {
-  const classes = ['bg-color', 'background-[--w-s-color-background]', 'background-[var(--w-s-color-background)]'];
-
-  const { css } = await uno.generate(classes);
-  expect(css).toMatchInlineSnapshot('""');
 });
 
 test('caret', async({ uno }) => {

--- a/test/color.js
+++ b/test/color.js
@@ -59,8 +59,8 @@ test("supports setting arbitrary border colors", async (t) => {
   expect(css).toMatchSnapshot();
 });
 
-test('bg color invalid class', async({ uno }) => {
-  const classes = ['bg-color'];
+test('invalid background color classes', async({ uno }) => {
+  const classes = ['bg-color', 'background-[--w-s-color-background]', 'background-[var(--w-s-color-background)]'];
 
   const { css } = await uno.generate(classes);
   expect(css).toMatchInlineSnapshot('""');

--- a/test/color.js
+++ b/test/color.js
@@ -16,7 +16,7 @@ test('opacity not created if invalid', async ({ uno }) => {
   const classes = ['opacity-1'];
 
   const { css } = await uno.generate(classes);
-  expect(css).toMatchInlineSnapshot('""');
+  expect(css).toHaveLength(0);
 });
 
 test('text colors', async({ uno }) => {
@@ -26,11 +26,19 @@ test('text colors', async({ uno }) => {
   expect(css).toMatchSnapshot();
 });
 
+test("supports setting arbitrary text colors", async ({ uno }) => {
+  const classes = ["text-[--w-s-color-border]", "text-[var(--w-s-color-border)]"];
+
+  const { css } = await uno.generate(classes);
+
+  expect(css).toMatchSnapshot();
+});
+
 test('text color invalid class', async({ uno }) => {
   const classes = ['text-color'];
 
   const { css } = await uno.generate(classes);
-  expect(css).toMatchInlineSnapshot('""');
+  expect(css).toHaveLength(0);
 });
 
 test('bg colors', async({ uno }) => {

--- a/test/color.js
+++ b/test/color.js
@@ -33,6 +33,14 @@ test('text color invalid class', async({ uno }) => {
   expect(css).toMatchInlineSnapshot('""');
 });
 
+test("supports setting arbitrary background colors", async (t) => {
+  const classes = ["background-[--w-s-color-background]", "background-[var(--w-s-color-background)]"];
+
+  const { css } = await t.uno.generate(classes);
+
+  expect(css).toMatchSnapshot();
+});
+
 test('bg colors', async({ uno }) => {
   const classes = [
     'bg-inherit',
@@ -40,6 +48,14 @@ test('bg colors', async({ uno }) => {
     'bg-current'];
 
   const { css } = await uno.generate(classes);
+  expect(css).toMatchSnapshot();
+});
+
+test("supports setting arbitrary background colors", async (t) => {
+  const classes = ["border-[--w-s-color-border]", "border-[var(--w-s-color-border)]"];
+
+  const { css } = await t.uno.generate(classes);
+
   expect(css).toMatchSnapshot();
 });
 

--- a/test/color.js
+++ b/test/color.js
@@ -34,7 +34,7 @@ test('text color invalid class', async({ uno }) => {
 });
 
 test("supports setting arbitrary background colors", async (t) => {
-  const classes = ["background-[--w-s-color-background]", "background-[var(--w-s-color-background)]"];
+  const classes = ["bg-[--w-s-color-background]", "bg-[var(--w-s-color-background)]"];
 
   const { css } = await t.uno.generate(classes);
 
@@ -51,7 +51,7 @@ test('bg colors', async({ uno }) => {
   expect(css).toMatchSnapshot();
 });
 
-test("supports setting arbitrary background colors", async (t) => {
+test("supports setting arbitrary border colors", async (t) => {
   const classes = ["border-[--w-s-color-border]", "border-[var(--w-s-color-border)]"];
 
   const { css } = await t.uno.generate(classes);

--- a/test/outline.js
+++ b/test/outline.js
@@ -5,8 +5,7 @@ import { lineWidth } from '#theme';
 setup();
 
 describe("outline", () => {
-  test("style", async ({ uno }) => {
-
+  test("supports setting outline styles", async ({ uno }) => {
     const classes = [
       "outline-none",
       "outline",
@@ -18,7 +17,7 @@ describe("outline", () => {
     expect(css).toMatchSnapshot();
   });
 
-  test("supports setting arbitrary outline colors", async (t) => {
+  test("supports setting outline colors", async ({ uno }) => {
     const classes = [
       "outline-inherit",
       "outline-current",
@@ -26,9 +25,7 @@ describe("outline", () => {
       "outline-[--w-s-color-border]",
       "outline-[var(--w-s-color-border)]",
     ];
-
-    const { css } = await t.uno.generate(classes);
-
+    const { css } = await uno.generate(classes);
     expect(css).toMatchSnapshot();
   });
 

--- a/test/outline.js
+++ b/test/outline.js
@@ -18,6 +18,20 @@ describe("outline", () => {
     expect(css).toMatchSnapshot();
   });
 
+  test("supports setting arbitrary outline colors", async (t) => {
+    const classes = [
+      "outline-inherit",
+      "outline-current",
+      "outline-transparent",
+      "outline-[--w-s-color-border]",
+      "outline-[var(--w-s-color-border)]",
+    ];
+
+    const { css } = await t.uno.generate(classes);
+
+    expect(css).toMatchSnapshot();
+  });
+
   test("width", async ({ uno }) => {
     const classes = Object.keys(lineWidth).map(width => [`outline-${width}`]).flat();
     const { css } = await uno.generate(classes);

--- a/test/semantic.js
+++ b/test/semantic.js
@@ -22,6 +22,10 @@ test('it generates css based on semantic warp tokens', async ({ uno }) => {
     's-border-b-negative-hover',
     's-border-x-warning-active',
     's-border-y-info-subtle-active',
+    's-divide',
+    's-divide-disabled',
+    's-divide-negative',
+    's-divide-info-subtle-active',
     's-outline',
     's-outline-focused',
     's-outline-negative',
@@ -47,6 +51,7 @@ test('it generates css based on semantic warp tokens', async ({ uno }) => {
     's-font-link-active',
     's-bordercolor',
     's-bordercolor-l-disabled',
+    's-dividecolor',
   ];
   const { css } = await uno.generate([...classes, ...antiClasses]);
   expect(css).toMatchSnapshot();


### PR DESCRIPTION
- Add support for css variables in arbitrary values for border and divide
- Add support for css variables in arbitrary values for text
- Add support for color and css variables in arbitrary values for outline
- Add support for semantic classes setting divide color

Co-authored by: @Skadefryd 