### PR TITLE
feat: support arbitrary values for order, columns and transition-timing

### DIFF
--- a/src/_rules/layout.js
+++ b/src/_rules/layout.js
@@ -21,15 +21,14 @@ export const overflows = [
 ];
 
 export const columns = [
-  [
-    /^columns-([1-9]|1[0-2])$/,
+  ['columns-auto', { 'columns': 'auto' }],
+  
+  [/^columns-([1-9]|1[0-2])$/,
     ([, d]) => ({ 'columns': h.number(d) }),
     { autocomplete: 'columns-<num>' },
   ],
-  ['columns-auto', { 'columns': 'auto' }],
   // matching arbitrary values
-  [
-    /^columns-\[(\d+)?]$/,
+  [/^columns-\[(\d+)?]$/,
     ([, d]) => ({ 'columns': h.number(d) }),
     { autocomplete: 'columns-<num>' },
   ],

--- a/src/_rules/layout.js
+++ b/src/_rules/layout.js
@@ -28,7 +28,7 @@ export const columns = [
     { autocomplete: 'columns-<num>' },
   ],
   // matching arbitrary values
-  [/^columns-\[(\d+)?]$/,
+  [/^columns-\[(\d+)]$/,
     ([, d]) => ({ 'columns': h.number(d) }),
     { autocomplete: 'columns-<num>' },
   ],

--- a/src/_rules/layout.js
+++ b/src/_rules/layout.js
@@ -22,14 +22,14 @@ export const overflows = [
 
 export const columns = [
   [
-    /^columns-(\d+)$/,
+    /^columns-([1-9]|1[0-2])$/,
     ([, d]) => ({ 'columns': h.number(d) }),
     { autocomplete: 'columns-<num>' },
   ],
   ['columns-auto', { 'columns': 'auto' }],
   // matching arbitrary values
   [
-    /^columns-\[(.\d*)?]$/,
+    /^columns-\[(\d*)?]$/,
     ([, d]) => ({ 'columns': h.number(d) }),
     { autocomplete: 'columns-<num>' },
   ],

--- a/src/_rules/layout.js
+++ b/src/_rules/layout.js
@@ -22,7 +22,7 @@ export const overflows = [
 
 export const columns = [
   ['columns-auto', { 'columns': 'auto' }],
-  
+
   [/^columns-([1-9]|1[0-2])$/,
     ([, d]) => ({ 'columns': h.number(d) }),
     { autocomplete: 'columns-<num>' },

--- a/src/_rules/layout.js
+++ b/src/_rules/layout.js
@@ -29,7 +29,7 @@ export const columns = [
   ['columns-auto', { 'columns': 'auto' }],
   // matching arbitrary values
   [
-    /^columns-\[(\d*)?]$/,
+    /^columns-\[(\d+)?]$/,
     ([, d]) => ({ 'columns': h.number(d) }),
     { autocomplete: 'columns-<num>' },
   ],

--- a/src/_rules/layout.js
+++ b/src/_rules/layout.js
@@ -1,3 +1,5 @@
+import { handler as h } from '#utils';
+
 const overflowValues = ["auto", "hidden", "visible", "scroll", "clip"];
 
 export const overflows = [
@@ -15,5 +17,20 @@ export const overflows = [
     /^(?:overflow)-([xy])-(.+)$/,
     ([, d, v]) =>
       (overflowValues.includes(v) ? { [`overflow-${d}`]: v } : undefined),
+  ],
+];
+
+export const columns = [
+  [
+    /^columns-(\d+)$/,
+    ([, d]) => ({ 'columns': h.number(d) }),
+    { autocomplete: 'columns-<num>' },
+  ],
+  ['columns-auto', { 'columns': 'auto' }],
+  // matching arbitrary values
+  [
+    /^columns-\[(.\d*)?]$/,
+    ([, d]) => ({ 'columns': h.number(d) }),
+    { autocomplete: 'columns-<num>' },
   ],
 ];

--- a/src/_rules/position.js
+++ b/src/_rules/position.js
@@ -7,7 +7,7 @@ export const positions = [
 
 export const orders = [
   [
-    /^order-(\d+)$/,
+    /^order-([1-9]|1[0-2])$/,
     ([, d]) => ({ 'order': h.number(d) }),
     { autocomplete: 'order-<num>' },
   ],
@@ -16,7 +16,7 @@ export const orders = [
   ['order-none', { order: '0' }],
   // matching arbitrary values
   [
-    /^order-\[(.\d*)?]$/,
+    /^order-\[(\d*)?]$/,
     ([, d]) => ({ 'order': h.number(d) }),
     { autocomplete: 'order-<num>' },
   ],

--- a/src/_rules/position.js
+++ b/src/_rules/position.js
@@ -16,7 +16,7 @@ export const orders = [
   ['order-none', { order: '0' }],
   // matching arbitrary values
   [
-    /^order-\[(\d*)?]$/,
+    /^order-\[(\d+)?]$/,
     ([, d]) => ({ 'order': h.number(d) }),
     { autocomplete: 'order-<num>' },
   ],

--- a/src/_rules/position.js
+++ b/src/_rules/position.js
@@ -6,17 +6,16 @@ export const positions = [
 ];
 
 export const orders = [
-  [
-    /^order-([1-9]|1[0-2])$/,
-    ([, d]) => ({ 'order': h.number(d) }),
-    { autocomplete: 'order-<num>' },
-  ],
   ['order-first', { order: '-9999' }],
   ['order-last', { order: '9999' }],
   ['order-none', { order: '0' }],
+
+  [/^order-([1-9]|1[0-2])$/,
+    ([, d]) => ({ 'order': h.number(d) }),
+    { autocomplete: 'order-<num>' },
+  ],
   // matching arbitrary values
-  [
-    /^order-\[(\d+)?]$/,
+  [/^order-\[(\d+)?]$/,
     ([, d]) => ({ 'order': h.number(d) }),
     { autocomplete: 'order-<num>' },
   ],

--- a/src/_rules/position.js
+++ b/src/_rules/position.js
@@ -15,7 +15,7 @@ export const orders = [
     { autocomplete: 'order-<num>' },
   ],
   // matching arbitrary values
-  [/^order-\[(\d+)?]$/,
+  [/^order-\[(\d+)]$/,
     ([, d]) => ({ 'order': h.number(d) }),
     { autocomplete: 'order-<num>' },
   ],

--- a/src/_rules/position.js
+++ b/src/_rules/position.js
@@ -14,6 +14,12 @@ export const orders = [
   ['order-first', { order: '-9999' }],
   ['order-last', { order: '9999' }],
   ['order-none', { order: '0' }],
+  // matching arbitrary values
+  [
+    /^order-\[(.\d*)?]$/,
+    ([, d]) => ({ 'order': h.number(d) }),
+    { autocomplete: 'order-<num>' },
+  ],
 ];
 
 export const justifies = [

--- a/src/_rules/transition.js
+++ b/src/_rules/transition.js
@@ -48,7 +48,7 @@ export const transitions = [
   ],
   // matching arbitrary values transition-timing
   [/^ease-\[(cubic-bezier\(.*\))]$/,
-    ([, value]) => ({ 'transition-timing-function': value}),
+    ([, value]) => ({ 'transition-timing-function': value }),
   ],
   // props
   [/^transition-property-(.+)$/,

--- a/src/_rules/transition.js
+++ b/src/_rules/transition.js
@@ -46,6 +46,10 @@ export const transitions = [
     ([, d]) => ({ 'transition-timing-function': easings[d] }),
     { autocomplete: 'ease-(linear|in|out|in-out)' },
   ],
+  // matching arbitrary values transition-timing
+  [/^ease-\[(cubic-bezier\(.*\))]$/,
+    ([, value]) => ({ 'transition-timing-function': value}),
+  ],
   // props
   [/^transition-property-(.+)$/,
     ([, v]) => ({ 'transition-property': h.global(v) || transitionProperty(v) }),

--- a/src/_utils/handlers/handlers.js
+++ b/src/_utils/handlers/handlers.js
@@ -48,7 +48,7 @@ export function px(str) {
   if (!Number.isNaN(num)) return unit ? `${round(num)}${unit}` : `${round(num)}px`;
 }
 export function number(str) {
-  const newStr = (str.startsWith('[') && str.endsWith(']')) ? bracket(str) : str;
+  const newStr = (str?.startsWith('[') && str?.endsWith(']')) ? bracket(str) : str;
   if (!numberRE.test(newStr)) return;
   const num = parseFloat(newStr);
   if (!Number.isNaN(num)) return round(num);

--- a/test/__snapshots__/layout.js.snap
+++ b/test/__snapshots__/layout.js.snap
@@ -1,0 +1,29 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`columns > allows values 1 to 12 1`] = `
+"/* layer: default */
+.columns-1{columns:1;}
+.columns-10{columns:10;}
+.columns-11{columns:11;}
+.columns-12{columns:12;}
+.columns-2{columns:2;}
+.columns-3{columns:3;}
+.columns-4{columns:4;}
+.columns-5{columns:5;}
+.columns-6{columns:6;}
+.columns-7{columns:7;}
+.columns-8{columns:8;}
+.columns-9{columns:9;}"
+`;
+
+exports[`columns > arbitrary values 1`] = `
+"/* layer: default */
+.columns-\\\\[14\\\\]{columns:14;}
+.columns-\\\\[20\\\\]{columns:20;}
+.columns-\\\\[50\\\\]{columns:50;}"
+`;
+
+exports[`columns > columns-auto 1`] = `
+"/* layer: default */
+.columns-auto{columns:auto;}"
+`;

--- a/test/__snapshots__/layout.js.snap
+++ b/test/__snapshots__/layout.js.snap
@@ -18,9 +18,9 @@ exports[`columns > allows values 1 to 12 1`] = `
 
 exports[`columns > arbitrary values 1`] = `
 "/* layer: default */
-.columns-\\\\[14\\\\]{columns:14;}
-.columns-\\\\[20\\\\]{columns:20;}
-.columns-\\\\[50\\\\]{columns:50;}"
+.columns-\\\\[13\\\\]{columns:13;}
+.columns-\\\\[25\\\\]{columns:25;}
+.columns-\\\\[55\\\\]{columns:55;}"
 `;
 
 exports[`columns > columns-auto 1`] = `

--- a/test/__snapshots__/position.js.snap
+++ b/test/__snapshots__/position.js.snap
@@ -560,6 +560,13 @@ exports[`order > allows values 1 to 12 1`] = `
 .order-9{order:9;}"
 `;
 
+exports[`order > arbitrary values 1`] = `
+"/* layer: default */
+.order-\\\\[14\\\\]{order:14;}
+.order-\\\\[20\\\\]{order:20;}
+.order-\\\\[50\\\\]{order:50;}"
+`;
+
 exports[`order > ensure -first, -last and -none is allowed and that the correct value is set 1`] = `
 "/* layer: default */
 .order-first{order:-9999;}

--- a/test/__snapshots__/transition.js.snap
+++ b/test/__snapshots__/transition.js.snap
@@ -32,6 +32,12 @@ exports[`ease 1`] = `
 .ease-out{transition-timing-function:cubic-bezier(0, 0, 0.2, 1);}"
 `;
 
+exports[`ease with arbitrary values 1`] = `
+"/* layer: default */
+.ease-\\\\[cubic-bezier\\\\(\\\\.29\\\\,\\\\ 1\\\\.01\\\\,\\\\ 1\\\\,\\\\ -0\\\\.68\\\\)\\\\]{transition-timing-function:cubic-bezier(.29, 1.01, 1, -0.68);}
+.ease-\\\\[cubic-bezier\\\\(0\\\\.95\\\\,0\\\\.05\\\\,0\\\\.795\\\\,0\\\\.035\\\\)\\\\]{transition-timing-function:cubic-bezier(0.95,0.05,0.795,0.035);}"
+`;
+
 exports[`transition 1`] = `
 "/* layer: default */
 .transition-all{transition-property:all;transition-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transition-duration:150ms;}

--- a/test/layout.js
+++ b/test/layout.js
@@ -60,9 +60,9 @@ describe('columns', () => {
   });
   test('arbitrary values', async ({ uno }) => {
     const classes = [
-      'columns-[14]',
-      'columns-[20]',
-      'columns-[50]',
+      'columns-[13]',
+      'columns-[25]',
+      'columns-[55]',
     ];
     const { css } = await uno.generate(classes);
     expect(css).toMatchSnapshot();

--- a/test/layout.js
+++ b/test/layout.js
@@ -41,3 +41,30 @@ describe("position", () => {
     `);
   });
 });
+
+describe('columns', () => {
+  test('allows values 1 to 12', async ({ uno }) => {
+    const range = Array.from({ length: 12 }).map((_, i) => i + 1);
+    const classes = range.map(value => `columns-${value}`);
+    const { css } = await uno.generate(classes);
+    expect(css).toMatchSnapshot();
+  });
+
+  test('columns-auto', async ({ uno }) => {
+    const styles = {
+      ['columns-auto']: 'auto',
+    };
+    const classes = Object.keys(styles);
+    const { css } = await uno.generate(classes);
+    expect(css).toMatchSnapshot();
+  });
+  test('arbitrary values', async ({ uno }) => {
+    const classes = [
+      'columns-[14]',
+      'columns-[20]',
+      'columns-[50]',
+    ];
+    const { css } = await uno.generate(classes);
+    expect(css).toMatchSnapshot();
+  });
+});

--- a/test/position.js
+++ b/test/position.js
@@ -31,6 +31,15 @@ describe('order', () => {
     const { css } = await uno.generate(classes);
     expect(css).toMatchSnapshot();
   });
+  test('arbitrary values', async ({ uno }) => {
+    const classes = [
+      'order-[14]',
+      'order-[20]',
+      'order-[50]',
+    ];
+    const { css } = await uno.generate(classes);
+    expect(css).toMatchSnapshot();
+  });
 });
 
 describe('justifies', () => {

--- a/test/transition.js
+++ b/test/transition.js
@@ -27,3 +27,13 @@ test('ease', async ({ uno }) => {
   const { css } = await uno.generate(classes);
   expect(css).toMatchSnapshot();
 });
+
+test('ease with arbitrary values', async ({ uno }) => {
+  const classes = [
+    'ease-[cubic-bezier(0.95,0.05,0.795,0.035)]',
+    'ease-[cubic-bezier(.29, 1.01, 1, -0.68)]',
+    'cubic-bezier(0.1, 0.7, 1, 0.1)'
+  ];
+  const { css } = await uno.generate(classes);
+  expect(css).toMatchSnapshot();
+});

--- a/test/transition.js
+++ b/test/transition.js
@@ -32,7 +32,7 @@ test('ease with arbitrary values', async ({ uno }) => {
   const classes = [
     'ease-[cubic-bezier(0.95,0.05,0.795,0.035)]',
     'ease-[cubic-bezier(.29, 1.01, 1, -0.68)]',
-    'cubic-bezier(0.1, 0.7, 1, 0.1)'
+    'cubic-bezier(0.1, 0.7, 1, 0.1)',
   ];
   const { css } = await uno.generate(classes);
   expect(css).toMatchSnapshot();


### PR DESCRIPTION
Fixes JIRA ticket: [WARP-413](https://nmp-jira.atlassian.net/browse/WARP-413)

- Adjust rule for order to only accept 1-12, and add support for arbitrary values for order following the unit-less convention, for example: `order-[14]`

- Add support for columns (accept 1-12), as well as, support arbitrary values for columns, following the unit-less convention, for example: `columns-[13]`

- Add support for arbitrary values for transition-timing function, following a unit-less convention together with `cubic-bezier`, for example: `ease-[cubic-bezier(0.95,0.05,0.795,0.035)]`

- Add tests for order, columns and transition-timing




