### PR TITLE
fix: Improve arbitrary values handling for border and divide

### DIFF
--- a/src/_rules/border.js
+++ b/src/_rules/border.js
@@ -1,51 +1,24 @@
 import { escapeSelector } from '@unocss/core';
-import { directionMap, cornerMap, resolveArbitraryValues } from "#utils";
+import { directionMap, cornerMap, resolveArbitraryValues } from '#utils';
 import { lineWidth } from '#theme';
 
-const borderStyles = [
-  "solid",
-  "dashed",
-  "dotted",
-  "double",
-  "hidden",
-  "none",
-  "groove",
-  "ridge",
-  "inset",
-  "outset",
-];
+const borderStyles = ['solid', 'dashed', 'dotted', 'double', 'hidden', 'none', 'groove', 'ridge', 'inset', 'outset'];
 
 export const borders = [
   // border-width
-  [
-    /^border(-[lrtbxy])?$/,
-    handleBorderWidth,
-    { autocomplete: ['border', 'border-<directions>'] },
-  ],
-  [
-    /^border(-[lrtbxy])?-(\d+)$/,
-    handleBorderWidth,
-    { autocomplete: [`border-(${Object.keys(lineWidth).join('|')})`, `border-<directions>-(${Object.keys(lineWidth).join('|')})`] },
-  ],
-  [
-    /^border(-[lrtbxy])?-\[(\d+)(rem|px|%)?]$/,
-    handleArbitraryBorderWidth,
-    { autocomplete: ['border-[<num>]', 'border-<directions>-[<num>]'] },
-  ],
+  [/^border(-[lrtbxy])?$/, handleBorderWidth, { autocomplete: ['border', 'border-<directions>'] }],
+  [/^border(-[lrtbxy])?-(\d+)$/, handleBorderWidth, { autocomplete: [`border-(${Object.keys(lineWidth).join('|')})`, `border-<directions>-(${Object.keys(lineWidth).join('|')})`] }],
+  [/^border(-[lrtbxy])?-\[(\d+)(rem|px|%)?]$/, handleArbitraryBorderWidth, { autocomplete: ['border-[<num>]', 'border-<directions>-[<num>]'] }],
 
   // border-color
   [/^border-transparent$/, () => ({ 'border-color': 'transparent' })],
   [/^border-inverted$/, () => ({ 'border-color': 'var(--w-s-border-inverted)' })],
   [/^border-inherit$/, () => ({ 'border-color': 'inherit' })],
   [/^border-current$/, () => ({ 'border-color': 'currentColor' })],
-  [/^border(-[lrtbxy])?-\[((?:var|--).*)]$/, handleArbitraryBorderColor],
+  [/^border(-[lrtbxy])?-\[(var\(.+\)|--.+|\D.*)]$/, handleArbitraryBorderColor],
 
   // border-style
-  [
-    new RegExp(`^border(-[lrtbxy])?-(${borderStyles.join('|')})$`),
-    handleBorderStyle,
-    { autocomplete: [`border-(${borderStyles.join('|')})`, `border-<directions>-(${borderStyles.join('|')})`] },
-  ],
+  [new RegExp(`^border(-[lrtbxy])?-(${borderStyles.join('|')})$`), handleBorderStyle, { autocomplete: [`border-(${borderStyles.join('|')})`, `border-<directions>-(${borderStyles.join('|')})`] }],
 ];
 
 function handleBorderWidth([, dir = '', width], { theme }) {
@@ -58,8 +31,8 @@ function handleArbitraryBorderWidth([, dir = '', value, unit], context) {
 }
 
 function handleArbitraryBorderColor([, dir = '', val]) {
-  const cssvar = val.startsWith('var') ? val : `var(${val})`;
-  return directionMap[dir.substring(1)]?.map((i) => [`border${i}-color`, cssvar]);
+  const cssVal = val.startsWith('--') ? `var(${val})` : val;
+  return directionMap[dir.substring(1)]?.map((i) => [`border${i}-color`, cssVal]);
 }
 
 function handleBorderStyle([, dir = '', style]) {
@@ -68,36 +41,43 @@ function handleBorderStyle([, dir = '', style]) {
 
 export const divide = [
   // border-width
-  [/^divide-([xy])$/, handleDivideBorder, { autocomplete: 'divide-(x|y)' }],
-  [
-    /^divide-([xy])-(\d+)(-reverse)?$/,
-    handleDivideBorder,
-    { autocomplete: [`divide-(x|y)-(${Object.keys(lineWidth).join('|')})`, `divide-(x|y)-(${Object.keys(lineWidth).join('|')})-reverse`] },
-  ],
+  [/^divide-([xy])$/, handleDivideWidth, { autocomplete: 'divide-(x|y)' }],
+  [/^divide-([xy])-(\d+)(-reverse)?$/, handleDivideWidth, { autocomplete: [`divide-(x|y)-(${Object.keys(lineWidth).join('|')})`, `divide-(x|y)-(${Object.keys(lineWidth).join('|')})-reverse`] }],
 
   // reverse order
   [/^divide-([xy])-reverse$/, ([, d]) => ({ [`--w-divide-${d}-reverse`]: 1 })],
 
+  // arbitrary border-width
+  [/^divide-([xy])-\[(\d+)(rem|px|%)?](-reverse)?$/, handleArbitraryDivideWidth],
+
   // arbitrary border-color
-  [/^divide(-[xy])?-\[((?:var|--).+)]$/, handleArbitraryDivideColor],
+  [/^divide(-[xy])?-\[(var\(.+\)|--.+|\D.*)]$/, handleArbitraryDivideColor],
 ];
 
-function handleDivideBorder([_selector, dir, width, reverse], { theme }) {
-  const applicableWidth = theme.lineWidth?.[width ?? 1];
-  if (applicableWidth) {
-    const sizes = directionMap[dir]?.map((i) => {
-      const reverseVar = `var(--w-divide-${dir}-reverse)`;
-      const reverseCalc = (i === directionMap[dir][1]) ? reverseVar : `calc(1 - ${reverseVar})`;
-      return `border${i}-width:calc(${applicableWidth} * ${reverseCalc})`;
-    });
-    if (sizes) {
-      return `.${escapeSelector(_selector)}>*+*{--w-divide-${dir}-reverse:${reverse ? 1 : 0};${sizes.join(';')};}`;
-    }
+function getDivideWidthStyles(selector, dir, width, reverse) {
+  const sizes = directionMap[dir]?.map((i) => {
+    const reverseVar = `var(--w-divide-${dir}-reverse)`;
+    const reverseCalc = i === directionMap[dir][1] ? reverseVar : `calc(1 - ${reverseVar})`;
+    return `border${i}-width:calc(${width} * ${reverseCalc})`;
+  });
+  if (sizes) {
+    return `.${escapeSelector(selector)}>*+*{--w-divide-${dir}-reverse:${reverse ? 1 : 0};${sizes.join(';')};}`;
   }
 }
 
+function handleDivideWidth([_selector, dir, width, reverse], { theme }) {
+  const applicableWidth = theme.lineWidth?.[width ?? 1];
+  if (applicableWidth) {
+    return getDivideWidthStyles(_selector, dir, applicableWidth, reverse);
+  }
+}
+
+function handleArbitraryDivideWidth([_selector, dir, width, unit, reverse], { theme }) {
+  return getDivideWidthStyles(_selector, dir, resolveArbitraryValues(width, unit, theme), reverse);
+}
+
 function handleArbitraryDivideColor([_selector, dir = '', val]) {
-  const cssRules = directionMap[dir.substring(1)]?.map((i) => `border${i}-color: ${val.startsWith('var') ? val : `var(${val})`}`);
+  const cssRules = directionMap[dir?.substring(1)]?.map((i) => `border${i}-color: ${val.startsWith('--') ? `var(${val})` : val}`);
   if (cssRules) return `.${escapeSelector(_selector)}>*+*{${cssRules.join(';')};}`;
 }
 
@@ -113,16 +93,10 @@ export const rounded = [
       'border-radius': resolveArbitraryValues(value, unit, context),
     }),
   ],
-  [/^rounded-([rltb]+)-\[(.\d*)(rem|px|%)?]$/,
-    ([, direction, value, unit], context) =>
-      cornerMap[direction].map((i) => [
-        `border${i}-radius`,
-        resolveArbitraryValues(value, unit,context),
-      ]),
-  ],
+  [/^rounded-([rltb]+)-\[(.\d*)(rem|px|%)?]$/, ([, direction, value, unit], context) => cornerMap[direction].map((i) => [`border${i}-radius`, resolveArbitraryValues(value, unit, context)])],
 ];
 
 function handleRounded([, corner = '', val], { theme }) {
   const applicableRadius = theme.borderRadius?.[val ?? 4];
-  if (applicableRadius) return cornerMap[corner].map(i => [`border${i}-radius`, applicableRadius]);
+  if (applicableRadius) return cornerMap[corner].map((i) => [`border${i}-radius`, applicableRadius]);
 }


### PR DESCRIPTION
Fixes handling of all types of supported arbitrary values for `border` and `divide`

- Values starting with `--` will be setting border-color (transcribed as `var(--...)`)
- Values added as `var(...)` will set `border-color`
- Values added as numbers followed by optional unit will set `border-width`
- Any other arbitrary values will set `border-color` (e.g. "#000000", "black", "rgb(0,0,0)", "asdfasdf"...)

This should also work with any valid direction ([lrtbxy] for border, [xy] for divide).