### PR TITLE
feat: Added rules for break-inside

### DIFF
--- a/src/_rules/static.js
+++ b/src/_rules/static.js
@@ -36,6 +36,10 @@ export const breaks = [
   ['break-words', { 'overflow-wrap': 'break-word' }],
   ['break-all', { 'word-break': 'break-all' }],
   ['break-keep', { 'word-break': 'keep-all' }],
+  ['break-inside-auto', { 'break-inside': 'auto' }],
+  ['break-inside-avoid', { 'break-inside': 'avoid' }],
+  ['break-inside-avoid-page', { 'break-inside': 'avoid-page' }],
+  ['break-inside-avoid-column', { 'break-inside': 'avoid-column' }],
 ];
 
 export const textOverflows = [

--- a/test/__snapshots__/static.js.snap
+++ b/test/__snapshots__/static.js.snap
@@ -86,6 +86,10 @@ exports[`static rules do static things 1`] = `
 .break-words{overflow-wrap:break-word;}
 .break-all{word-break:break-all;}
 .break-keep{word-break:keep-all;}
+.break-inside-auto{break-inside:auto;}
+.break-inside-avoid{break-inside:avoid;}
+.break-inside-avoid-page{break-inside:avoid-page;}
+.break-inside-avoid-column{break-inside:avoid-column;}
 .truncate{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
 .text-ellipsis{text-overflow:ellipsis;}
 .text-clip{text-overflow:clip;}


### PR DESCRIPTION

Adds missing rules for: https://warp-ds.github.io/css-docs/break-inside#setting-the-break-inside-behavior

Reported here: https://sch-chat.slack.com/archives/C04P0GYTHPV/p1713167639919199

